### PR TITLE
chore: update pgsql exposed port

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     container_name: fuel-explorer-pgsql
     image: postgres:latest
     ports:
-      - "5432:5432"
+      - "5435:5432"
     volumes:
       - fuel-explorer-db:/usr/local/postgres
     environment:


### PR DESCRIPTION
Update pgsql exposed port to avoid conflicts with other PostgreSQL processes running on the host machine.