### PR TITLE
feat: Create Indexer for transactions

### DIFF
--- a/packages/indexer/schema/indexer.schema.graphql
+++ b/packages/indexer/schema/indexer.schema.graphql
@@ -3,79 +3,27 @@ schema {
 }
 
 type QueryRoot {
-  block: Block
   tx: Tx
-  account: Account
-  contract: Contract
 }
 
-# https://ethereum.org/en/developers/docs/data-and-analytics/block-explorers/
-
-type Block {
+type ScriptTx {
   id: ID!
-  height: UInt8!
-  producer: Bytes32!
-  timestamp: Int8!
-  gas_limit: UInt8!
-  hash: Bytes32! @unique
-}
-
-type Tx {
-  id: ID!
-  block: Block!
-  hash: Bytes32! @unique
-  timestamp: Int8!
   status: Json!
-  value: UInt8!
-  tokens_transferred: Json!
+  age: Int8!
+  from: Bytes32!
+  to: Bytes32!
 }
 
-type Account {
-  id: Address! @unique
-  last_seen: UInt8!
-}
-
-type Contract {
-  id: ContractId! @unique
-  last_seen: UInt8!
-}
-
-type Transfer {
+type CreateTx {
   id: ID!
-  contract_id: Contract!
-  # `to` is a reserved SQL keyword
-  receiver: ContractId! @indexed
-  amount: UInt8!
-  asset_id: AssetId! @indexed
+  status: Json!
+  age: Int8!
+  from: Bytes32!
+  to: Bytes32!
 }
 
-type TransferOut {
+type MintTx {
   id: ID!
-  contract_id: Contract!
-  # `to` is a reserved SQL keyword
-  receiver: Account!
-  amount: UInt8!
-  asset_id: AssetId! @indexed
-}
-
-type ScriptResult {
-  id: ID!
-  result: UInt8!
-  gas_used: UInt8!
-}
-
-type Log {
-  id: ID!
-  contract_id: ContractId!
-  rb: UInt8!
-}
-
-type MessageOut {
-  id: MessageId! @unique
-  sender: Address!
-  recipient: Address!
-  amount: UInt8!
-  nonce: Bytes32!
-  len: UInt8!
-  digest: Bytes32!
+  age: Int8!
+  to: Bytes32!
 }

--- a/packages/indexer/schema/indexer.schema.graphql
+++ b/packages/indexer/schema/indexer.schema.graphql
@@ -8,10 +8,8 @@ type QueryRoot {
 
 type TransactionEntity {
   id: ID!
-  #status: Json
+  status: Json
   age: Int8!
   inputs: Json
   outputs: Json!
-  #tx_pointer: TxPointer
-  #meta_data: Json
 }

--- a/packages/indexer/schema/indexer.schema.graphql
+++ b/packages/indexer/schema/indexer.schema.graphql
@@ -8,14 +8,10 @@ type QueryRoot {
 
 type TransactionEntity {
   id: ID!
-  status: Json!
+  #status: Json
   age: Int8!
-  input_address: Bytes32!
-  output_address: Bytes32!
-}
-
-type MintTransactionEntity {
-  id: ID!
-  age: Int8!
-  output_address: Bytes32!
+  inputs: Json
+  outputs: Json!
+  #tx_pointer: TxPointer
+  #meta_data: Json
 }

--- a/packages/indexer/schema/indexer.schema.graphql
+++ b/packages/indexer/schema/indexer.schema.graphql
@@ -3,27 +3,19 @@ schema {
 }
 
 type QueryRoot {
-  tx: Tx
+  tx: TransactionEntity
 }
 
-type ScriptTx {
+type TransactionEntity {
   id: ID!
   status: Json!
   age: Int8!
-  from: Bytes32!
-  to: Bytes32!
+  input_address: Bytes32!
+  output_address: Bytes32!
 }
 
-type CreateTx {
-  id: ID!
-  status: Json!
-  age: Int8!
-  from: Bytes32!
-  to: Bytes32!
-}
-
-type MintTx {
+type MintTransactionEntity {
   id: ID!
   age: Int8!
-  to: Bytes32!
+  output_address: Bytes32!
 }

--- a/packages/indexer/src/lib.rs
+++ b/packages/indexer/src/lib.rs
@@ -1,10 +1,10 @@
 extern crate alloc;
 use fuel_indexer_macros::indexer;
 use fuel_indexer_plugin::prelude::*;
+use serde_json::Value;
 
 #[indexer(manifest = "indexer.manifest.yaml")]
 pub mod explorer_index {
-    use serde_json::Value;
 
     fn index_transaction(block_data: BlockData) {
         for tx in block_data.transactions.iter() {
@@ -24,14 +24,17 @@ pub mod explorer_index {
                     // );
 
                     // let output: Value = serde_json::from_str(t.outputs());
-                    let inputs: Value = serde_json::from_str(data.inputs());
+                    // let inputs: Value = serde_json::from_str(data.inputs());
                     // let status: Value = serde_json::from_str(tx.status.clone());
+
+                    let inputs = data.inputs();
+                    let inputs_json: Value = serde_json::to_string(&inputs).unwrap().into();
 
                     TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
                         // status: Some(status),
                         age: block_data.time,
-                        inputs: Some(inputs),
+                        inputs: Some(Json(inputs_json.to_string())),
                         outputs: Json(serde_json::to_value(data.outputs()).unwrap().to_string()),
                     }
                     .save();
@@ -45,14 +48,17 @@ pub mod explorer_index {
                     //     .as_str(),
                     // );
                     
-                    let inputs: Value = serde_json::from_str(data.inputs());
+                    // let inputs: Value = serde_json::from_str(data.inputs());
                     // let status: Value = serde_json::from_str(tx.status.clone());
+
+                    let inputs = data.inputs();
+                    let inputs_json: Value = serde_json::to_string(&inputs).unwrap().into();
 
                     TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
                         // status: Some(status),
                         age: block_data.time,
-                        inputs: Some(inputs),
+                        inputs: Some(Json(inputs_json.to_string())),
                         outputs: Json(serde_json::to_value(data.outputs()).unwrap().to_string()),
                     }
                     .save();

--- a/packages/indexer/src/lib.rs
+++ b/packages/indexer/src/lib.rs
@@ -4,88 +4,71 @@ use fuel_indexer_plugin::prelude::*;
 
 #[indexer(manifest = "indexer.manifest.yaml")]
 pub mod explorer_index {
+    use serde_json::Value;
+
     fn index_transaction(block_data: BlockData) {
         for tx in block_data.transactions.iter() {
-            let mut from: Option<&Address> = None;
-            let mut to: Option<&Address> = None;
+            // let mut from: Option<&Address> = None;
+            // let mut to: Option<&Address> = None;
+
+            // Logger::info(format!("{:?}", &tx.transaction).as_str());
 
             match &tx.transaction {
                 Transaction::Script(data) => {
-                    Logger::info(
-                        format!(
-                            "(>^‿^)> Inside a script transaction {:?}.",
-                            block_data.height
-                        )
-                        .as_str(),
-                    );
+                    // Logger::info(
+                    //     format!(
+                    //         "(>^‿^)> Inside a script transaction {:?}.",
+                    //         block_data.height
+                    //     )
+                    //     .as_str(),
+                    // );
 
-                    for input in data.inputs() {
-                        from = input.input_owner();
-                        if from.is_some() {
-                            break;
-                        }
-                    }
-                    for output in data.outputs() {
-                        to = output.to();
-                        if to.is_some() {
-                            break;
-                        }
-                    }
+                    // let output: Value = serde_json::from_str(t.outputs());
+                    let inputs: Value = serde_json::from_str(data.inputs());
+                    // let status: Value = serde_json::from_str(tx.status.clone());
 
                     TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
-                        status: tx.status.clone().into(),
+                        // status: Some(status),
                         age: block_data.time,
-                        input_address: Bytes32::new(**from.unwrap()),
-                        output_address: Bytes32::new(**to.unwrap()),
+                        inputs: Some(inputs),
+                        outputs: Json(serde_json::to_value(data.outputs()).unwrap().to_string()),
                     }
                     .save();
                 }
                 Transaction::Create(data) => {
-                    Logger::info(
-                        format!(
-                            "<(^.^)> Inside a create transaction {:?}.",
-                            block_data.height
-                        )
-                        .as_str(),
-                    );
-
-                    for input in data.inputs() {
-                        from = input.input_owner();
-                        if from.is_some() {
-                            break;
-                        }
-                    }
-                    for output in data.outputs() {
-                        to = output.to();
-                        if to.is_some() {
-                            break;
-                        }
-                    }
+                    // Logger::info(
+                    //     format!(
+                    //         "<(^.^)> Inside a create transaction {:?}.",
+                    //         block_data.height
+                    //     )
+                    //     .as_str(),
+                    // );
+                    
+                    let inputs: Value = serde_json::from_str(data.inputs());
+                    // let status: Value = serde_json::from_str(tx.status.clone());
 
                     TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
-                        status: tx.status.clone().into(),
+                        // status: Some(status),
                         age: block_data.time,
-                        input_address: Bytes32::new(**from.unwrap()),
-                        output_address: Bytes32::new(**to.unwrap()),
+                        inputs: Some(inputs),
+                        outputs: Json(serde_json::to_value(data.outputs()).unwrap().to_string()),
                     }
                     .save();
                 }
                 Transaction::Mint(data) => {
-                    Logger::info(
-                        format!("<(^‿^<) Inside a mint transaction {:?}.", block_data.height)
-                            .as_str(),
-                    );
+                    // Logger::info(
+                    //     format!("<(^‿^<) Inside a mint transaction {:?}.", block_data.height)
+                    //         .as_str(),
+                    // );
 
-                    for output in data.outputs() {
-                        to = output.to();
-                    }
-
-                    MintTransactionEntity {
+                    TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
+                        // status: None,
                         age: block_data.time,
-                        output_address: Bytes32::new(**to.unwrap()),
+                        inputs: None,
+                        outputs: Json(serde_json::to_value(data.outputs()).unwrap().to_string()),
                     }
                     .save();
                 }

--- a/packages/indexer/src/lib.rs
+++ b/packages/indexer/src/lib.rs
@@ -1,264 +1,79 @@
 extern crate alloc;
 use fuel_indexer_macros::indexer;
 use fuel_indexer_plugin::prelude::*;
-use std::collections::HashSet;
 
 #[indexer(manifest = "indexer.manifest.yaml")]
-pub mod indexer_index_mod {
-    fn index_explorer_data(block_data: BlockData) {
-        let log_txt = format!("Block height {:?}", block_data.height.to_string());
-        Logger::info(&log_txt);
-
-        let mut block_gas_limit = 0;
-
-        // Convert the deserialized block `BlockData` struct that we get from our Fuel node, into
-        // a block entity `Block` that we can persist to the database. The `Block` type below is
-        // defined in our schema/explorer.graphql and represents the type that we will
-        // save to our database.
-        let producer = block_data.producer.unwrap_or(Bytes32::zeroed());
-
-        let block = Block {
-            id: first8_bytes_to_u64(block_data.id),
-            height: block_data.height,
-            producer,
-            hash: block_data.id,
-            timestamp: block_data.time,
-            gas_limit: block_gas_limit,
-        };
-
-        // Now that we've created the object for the database, let's save it.
-        block.save();
-
-        // Keep track of some Receipt data involved in this transaction.
-        let mut accounts = HashSet::new();
-        let mut contracts = HashSet::new();
+pub mod explorer_index {
+    fn index_transaction(block_data: BlockData) {
+        // Logger::info(format!("{:?}", &block_data).as_str());
 
         for tx in block_data.transactions.iter() {
-            let mut tx_amount = 0;
-            let mut tokens_transferred = Vec::new();
 
-            // `Transaction::Script`, `Transaction::Create`, and `Transaction::Mint`
-            // are unused but demonstrate properties like gas, inputs,
-            // outputs, script_data, and other pieces of metadata. You can access
-            // properties that have the corresponding transaction `Field` traits
-            // implemented; examples below.
+            let mut from: Option<&Address> = None;
+            let mut to: Option<&Address> = None;
+            
             match &tx.transaction {
                 #[allow(unused)]
-                Transaction::Script(t) => {
-                    Logger::info("Inside a script transaction. (>^‿^)>");
+                Transaction::Script(data) => {
+                    // Logger::info("Inside a script transaction. (>^‿^)>");
+                    for input in data.inputs() {
+                        from = input.input_owner();
+                    }
+                    for output in data.outputs() {
+                        to = output.to();
+                    }
 
-                    let gas_limit = t.gas_limit();
-                    let gas_price = t.gas_price();
-                    let maturity = t.maturity();
-                    let script = t.script();
-                    let script_data = t.script_data();
-                    let receipts_root = t.receipts_root();
-                    let inputs = t.inputs();
-                    let outputs = t.outputs();
-                    let witnesses = t.witnesses();
-
-                    let json = &tx.transaction.to_json();
-                    block_gas_limit += gas_limit;
+                    let tx_entity = ScriptTx {
+                        id: first8_bytes_to_u64(tx.id),
+                        status: tx.status.clone().into(),
+                        age: block_data.time,
+                        from: Bytes32::new(**from.unwrap()),
+                        to: Bytes32::new(**to.unwrap())
+                    };
+        
+                    tx_entity.save();
                 }
                 #[allow(unused)]
-                Transaction::Create(t) => {
-                    Logger::info("Inside a create transaction. <(^.^)>");
+                Transaction::Create(data) => {
+                    // Logger::info("Inside a create transaction. <(^.^)>");
 
-                    let gas_limit = t.gas_limit();
-                    let gas_price = t.gas_price();
-                    let maturity = t.maturity();
-                    let salt = t.salt();
-                    let bytecode_length = t.bytecode_length();
-                    let bytecode_witness_index = t.bytecode_witness_index();
-                    let inputs = t.inputs();
-                    let outputs = t.outputs();
-                    let witnesses = t.witnesses();
-                    let storage_slots = t.storage_slots();
-                    block_gas_limit += gas_limit;
+                    for input in data.inputs() {
+                        from = input.input_owner();
+                    }
+                    for output in data.outputs() {
+                        to = output.to();
+                    }
+
+                    let tx_entity = CreateTx {
+                        id: first8_bytes_to_u64(tx.id),
+                        status: tx.status.clone().into(),
+                        age: block_data.time,
+                        from: Bytes32::new(**from.unwrap()),
+                        to: Bytes32::new(**to.unwrap())
+                    };
+        
+                    tx_entity.save();
                 }
                 #[allow(unused)]
-                Transaction::Mint(t) => {
-                    Logger::info("Inside a mint transaction. <(^‿^<)");
+                Transaction::Mint(data) => {
+                    // Logger::info("Inside a mint transaction. <(^‿^<)");
 
-                    let tx_pointer = t.tx_pointer();
-                    let outputs = t.outputs();
+                    let tx_pointer = data.tx_pointer();
+                    let outputs = data.outputs();
+
+                    for output in data.outputs() {
+                        to = output.to();
+                    }
+
+                    let tx_entity = MintTx {
+                        id: first8_bytes_to_u64(tx.id),
+                        age: block_data.time,
+                        to: Bytes32::new(**to.unwrap())
+                    };
+
+                    tx_entity.save();
                 }
             }
-
-            for receipt in &tx.receipts {
-                // You can handle each receipt in a transaction `TransactionData` as you like.
-                //
-                // Below demonstrates how you can use parts of a receipt `Receipt` in order
-                // to persist entities defined in your GraphQL schema, to the database.
-                match receipt {
-                    #[allow(unused)]
-                    Receipt::Call { id, .. } => {
-                        contracts.insert(Contract {
-                            id: *id,
-                            last_seen: 0,
-                        });
-                    }
-                    #[allow(unused)]
-                    Receipt::ReturnData { id, .. } => {
-                        contracts.insert(Contract {
-                            id: *id,
-                            last_seen: 0,
-                        });
-                    }
-                    #[allow(unused)]
-                    Receipt::Transfer {
-                        id,
-                        to,
-                        asset_id,
-                        amount,
-                        ..
-                    } => {
-                        contracts.insert(Contract {
-                            id: *id,
-                            last_seen: 0,
-                        });
-
-                        let transfer = Transfer {
-                            id: first8_bytes_to_u64(bytes32_from_inputs(
-                                id,
-                                [id.to_vec(), to.to_vec(), asset_id.to_vec()].concat(),
-                            )),
-                            contract_id: *id,
-                            receiver: *to,
-                            amount: *amount,
-                            asset_id: *asset_id,
-                        };
-
-                        transfer.save();
-                        tokens_transferred.push(asset_id.to_string());
-                    }
-                    #[allow(unused)]
-                    Receipt::TransferOut {
-                        id,
-                        to,
-                        amount,
-                        asset_id,
-                        ..
-                    } => {
-                        contracts.insert(Contract {
-                            id: *id,
-                            last_seen: 0,
-                        });
-
-                        accounts.insert(Account {
-                            id: *to,
-                            last_seen: 0,
-                        });
-
-                        tx_amount += amount;
-                        let transfer_out = TransferOut {
-                            id: first8_bytes_to_u64(bytes32_from_inputs(
-                                id,
-                                [id.to_vec(), to.to_vec(), asset_id.to_vec()].concat(),
-                            )),
-                            contract_id: *id,
-                            receiver: *to,
-                            amount: *amount,
-                            asset_id: *asset_id,
-                        };
-
-                        transfer_out.save();
-                    }
-                    #[allow(unused)]
-                    Receipt::Log { id, rb, .. } => {
-                        contracts.insert(Contract {
-                            id: *id,
-                            last_seen: 0,
-                        });
-                        let log = Log {
-                            id: first8_bytes_to_u64(bytes32_from_inputs(
-                                id,
-                                u64::to_le_bytes(*rb).to_vec(),
-                            )),
-                            contract_id: *id,
-                            rb: *rb,
-                        };
-
-                        log.save();
-                    }
-                    #[allow(unused)]
-                    Receipt::LogData { id, .. } => {
-                        contracts.insert(Contract {
-                            id: *id,
-                            last_seen: 0,
-                        });
-
-                        Logger::info("LogData types are unused in this example. (>'')>");
-                    }
-                    #[allow(unused)]
-                    Receipt::ScriptResult { result, gas_used } => {
-                        let result: u64 = match result {
-                            ScriptExecutionResult::Success => 1,
-                            ScriptExecutionResult::Revert => 2,
-                            ScriptExecutionResult::Panic => 3,
-                            ScriptExecutionResult::GenericFailure(_) => 4,
-                        };
-                        let r = ScriptResult {
-                            id: first8_bytes_to_u64(bytes32_from_inputs(
-                                &[0u8; 32],
-                                u64::to_be_bytes(result).to_vec(),
-                            )),
-                            result,
-                            gas_used: *gas_used,
-                        };
-                        r.save();
-                    }
-                    #[allow(unused)]
-                    Receipt::MessageOut {
-                        sender,
-                        recipient,
-                        amount,
-                        ..
-                    } => {
-                        tx_amount += amount;
-                        accounts.insert(Account {
-                            id: *sender,
-                            last_seen: 0,
-                        });
-                        accounts.insert(Account {
-                            id: *recipient,
-                            last_seen: 0,
-                        });
-
-                        Logger::info("LogData types are unused in this example. (>'')>");
-                    }
-                    _ => {
-                        Logger::info("This type is not handled yet.");
-                    }
-                }
-            }
-
-            // Persist the transaction to the database via the `Tx` object defined in the GraphQL schema.
-            let tx_entity = Tx {
-                block: block.id,
-                hash: tx.id,
-                timestamp: block.timestamp,
-                id: first8_bytes_to_u64(tx.id),
-                value: tx_amount,
-                status: tx.status.clone().into(),
-                tokens_transferred: Json(
-                    serde_json::to_value(tokens_transferred)
-                        .unwrap()
-                        .to_string(),
-                ),
-            };
-
-            tx_entity.save();
-        }
-
-        // Save all of our accounts
-        for account in accounts.iter() {
-            account.save();
-        }
-
-        // Save all of our contracts
-        for contract in contracts.iter() {
-            contract.save();
         }
     }
 }

--- a/packages/indexer/src/lib.rs
+++ b/packages/indexer/src/lib.rs
@@ -8,9 +8,6 @@ pub mod explorer_index {
 
     fn index_transaction(block_data: BlockData) {
         for tx in block_data.transactions.iter() {
-            // let mut from: Option<&Address> = None;
-            // let mut to: Option<&Address> = None;
-
             // Logger::info(format!("{:?}", &tx.transaction).as_str());
 
             match &tx.transaction {
@@ -23,18 +20,13 @@ pub mod explorer_index {
                     //     .as_str(),
                     // );
 
-                    // let output: Value = serde_json::from_str(t.outputs());
-                    // let inputs: Value = serde_json::from_str(data.inputs());
-                    // let status: Value = serde_json::from_str(tx.status.clone());
-
-                    let inputs = data.inputs();
-                    let inputs_json: Value = serde_json::to_string(&inputs).unwrap().into();
+                    let inputs: Value = serde_json::to_string(&data.inputs()).unwrap().into();
 
                     TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
-                        // status: Some(status),
+                        status: Some(tx.status.clone().into()),
                         age: block_data.time,
-                        inputs: Some(Json(inputs_json.to_string())),
+                        inputs: Some(Json(inputs.to_string())),
                         outputs: Json(serde_json::to_value(data.outputs()).unwrap().to_string()),
                     }
                     .save();
@@ -47,18 +39,14 @@ pub mod explorer_index {
                     //     )
                     //     .as_str(),
                     // );
-                    
-                    // let inputs: Value = serde_json::from_str(data.inputs());
-                    // let status: Value = serde_json::from_str(tx.status.clone());
 
-                    let inputs = data.inputs();
-                    let inputs_json: Value = serde_json::to_string(&inputs).unwrap().into();
+                    let inputs: Value = serde_json::to_string(&data.inputs()).unwrap().into();
 
                     TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
-                        // status: Some(status),
+                        status: Some(tx.status.clone().into()),
                         age: block_data.time,
-                        inputs: Some(Json(inputs_json.to_string())),
+                        inputs: Some(Json(inputs.to_string())),
                         outputs: Json(serde_json::to_value(data.outputs()).unwrap().to_string()),
                     }
                     .save();
@@ -71,7 +59,7 @@ pub mod explorer_index {
 
                     TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
-                        // status: None,
+                        status: None,
                         age: block_data.time,
                         inputs: None,
                         outputs: Json(serde_json::to_value(data.outputs()).unwrap().to_string()),

--- a/packages/indexer/src/lib.rs
+++ b/packages/indexer/src/lib.rs
@@ -5,73 +5,89 @@ use fuel_indexer_plugin::prelude::*;
 #[indexer(manifest = "indexer.manifest.yaml")]
 pub mod explorer_index {
     fn index_transaction(block_data: BlockData) {
-        // Logger::info(format!("{:?}", &block_data).as_str());
-
         for tx in block_data.transactions.iter() {
-
             let mut from: Option<&Address> = None;
             let mut to: Option<&Address> = None;
-            
+
             match &tx.transaction {
-                #[allow(unused)]
                 Transaction::Script(data) => {
-                    // Logger::info("Inside a script transaction. (>^‿^)>");
+                    Logger::info(
+                        format!(
+                            "(>^‿^)> Inside a script transaction {:?}.",
+                            block_data.height
+                        )
+                        .as_str(),
+                    );
+
                     for input in data.inputs() {
                         from = input.input_owner();
+                        if from.is_some() {
+                            break;
+                        }
                     }
                     for output in data.outputs() {
                         to = output.to();
+                        if to.is_some() {
+                            break;
+                        }
                     }
 
-                    let tx_entity = ScriptTx {
+                    TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
                         status: tx.status.clone().into(),
                         age: block_data.time,
-                        from: Bytes32::new(**from.unwrap()),
-                        to: Bytes32::new(**to.unwrap())
-                    };
-        
-                    tx_entity.save();
+                        input_address: Bytes32::new(**from.unwrap()),
+                        output_address: Bytes32::new(**to.unwrap()),
+                    }
+                    .save();
                 }
-                #[allow(unused)]
                 Transaction::Create(data) => {
-                    // Logger::info("Inside a create transaction. <(^.^)>");
+                    Logger::info(
+                        format!(
+                            "<(^.^)> Inside a create transaction {:?}.",
+                            block_data.height
+                        )
+                        .as_str(),
+                    );
 
                     for input in data.inputs() {
                         from = input.input_owner();
+                        if from.is_some() {
+                            break;
+                        }
                     }
                     for output in data.outputs() {
                         to = output.to();
+                        if to.is_some() {
+                            break;
+                        }
                     }
 
-                    let tx_entity = CreateTx {
+                    TransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
                         status: tx.status.clone().into(),
                         age: block_data.time,
-                        from: Bytes32::new(**from.unwrap()),
-                        to: Bytes32::new(**to.unwrap())
-                    };
-        
-                    tx_entity.save();
+                        input_address: Bytes32::new(**from.unwrap()),
+                        output_address: Bytes32::new(**to.unwrap()),
+                    }
+                    .save();
                 }
-                #[allow(unused)]
                 Transaction::Mint(data) => {
-                    // Logger::info("Inside a mint transaction. <(^‿^<)");
-
-                    let tx_pointer = data.tx_pointer();
-                    let outputs = data.outputs();
+                    Logger::info(
+                        format!("<(^‿^<) Inside a mint transaction {:?}.", block_data.height)
+                            .as_str(),
+                    );
 
                     for output in data.outputs() {
                         to = output.to();
                     }
 
-                    let tx_entity = MintTx {
+                    MintTransactionEntity {
                         id: first8_bytes_to_u64(tx.id),
                         age: block_data.time,
-                        to: Bytes32::new(**to.unwrap())
-                    };
-
-                    tx_entity.save();
+                        output_address: Bytes32::new(**to.unwrap()),
+                    }
+                    .save();
                 }
             }
         }


### PR DESCRIPTION
## Changes

- There is 1 transaction query target which consists of 3 transaction types
  - `Script`
  - `Create`
  - `Mint`
- The transaction type in the schema is pruned meaning it does not contain all available fields / data from the client. Additional fields may be added in the future
- The transaction consists of two optional fields:
  - Success state (minting does not have one)
  - UTXO Inputs (minting does not have inputs)
- The transaction has 3 mandatory fields
  - ID used by the indexer
  - Age is the block time
  - Outputs
- The schema type do not currently use strict types and thus the following fields use `Json` for now
  - Success state
  - Inputs
  - Outputs

## Notes

- WIP: awaiting indexer features to allow the crate to compile and use strict types

## Issue

Closes #12 