### PR TITLE
feat: add scalar config

### DIFF
--- a/packages/app/src/app/account/[id]/predicate/page.tsx
+++ b/packages/app/src/app/account/[id]/predicate/page.tsx
@@ -11,7 +11,10 @@ export default async function AccountPredicatePage({
   params: { id },
 }: PageProps) {
   const predicate = await getPredicate({ owner: id });
-  return <AccountPredicate bytecode={predicate?.bytecode} />;
+
+  if (!predicate?.bytecode) return null;
+
+  return <AccountPredicate bytecode={predicate.bytecode} />;
 }
 
 export const revalidate = 100;

--- a/packages/app/src/systems/Account/actions/get-predicate.ts
+++ b/packages/app/src/systems/Account/actions/get-predicate.ts
@@ -9,6 +9,8 @@ const schema = z.object({
 });
 
 export const getPredicate = act(schema, async (input) => {
+  if (!input.owner) return null;
+
   const { data } = await sdk.getPredicate({ address: input.owner });
   return data.predicate;
 });

--- a/packages/app/src/systems/Core/components/Utxos/Utxos.tsx
+++ b/packages/app/src/systems/Core/components/Utxos/Utxos.tsx
@@ -21,6 +21,8 @@ type UtxoItemProps = {
 };
 
 function UtxoItem({ item, assetId, style }: UtxoItemProps) {
+  if (!item.utxoId) return null;
+
   const asset = useAsset(assetId);
   const classes = styles();
   return (

--- a/packages/app/src/systems/Transaction/component/TxInput/TxInput.tsx
+++ b/packages/app/src/systems/Transaction/component/TxInput/TxInput.tsx
@@ -30,6 +30,8 @@ export type TxInputProps = CardProps & {
 const TxInputCoin = createComponent<TxInputProps, typeof Collapsible>({
   id: 'TxInputCoin',
   render: (_, { input, ...props }) => {
+    if (!input.assetId) return null;
+
     const assetId = input.assetId;
     const amount = input.totalAmount;
     const inputs = input.inputs as InputCoin[];
@@ -57,9 +59,13 @@ const TxInputCoin = createComponent<TxInputProps, typeof Collapsible>({
                   ({asset.symbol})
                 </Text>
               )}
-              <Address value={input.assetId} fixed="b256" />
+              <Address value={assetId} fixed="b256" />
             </Text>
-            <Address prefix="From:" value={input.owner} className="text-white">
+            <Address
+              prefix="From:"
+              value={input.owner || ''}
+              className="text-white"
+            >
               <Address.Link as={NextLink} href={`/account/${input.owner}`}>
                 View Account
               </Address.Link>
@@ -81,6 +87,8 @@ const TxInputContract = createComponent<TxInputProps, typeof Card>({
   id: 'TxInputContract',
   render: (_, { input, ...props }) => {
     const classes = styles();
+
+    if (!input.contractId) return null;
     const contractId = input.contractId;
 
     return (
@@ -108,6 +116,8 @@ const TxInputMessage = createComponent<TxInputProps, typeof Collapsible>({
   id: 'TxInputMessage',
   render: (_, { input, ...props }) => {
     const { sender, recipient, data } = input;
+
+    if (!sender || !recipient) return null;
 
     return (
       <Collapsible {...props}>

--- a/packages/app/src/systems/Transaction/component/TxOutput/TxOutput.tsx
+++ b/packages/app/src/systems/Transaction/component/TxOutput/TxOutput.tsx
@@ -29,6 +29,8 @@ const TxOutputCoin = createComponent<TxOutputProps, typeof Card>({
   id: 'TxOutputCoin',
   render: (_, { output, title, ...props }) => {
     const classes = styles();
+
+    if (!output.assetId) return null;
     const assetId = output.assetId;
     const amount = output.totalAmount;
     const asset = useAsset(assetId);
@@ -57,7 +59,7 @@ const TxOutputCoin = createComponent<TxOutputProps, typeof Card>({
                 <Address value={output.assetId} fixed="b256" />
               </Text>
               <HStack>
-                <Address prefix="To:" value={output.to}>
+                <Address prefix="To:" value={output.to || ''}>
                   <Address.Link as={NextLink} href={`/account/${output.to}`}>
                     View Account
                   </Address.Link>
@@ -140,7 +142,7 @@ const TxOutputMessage = createComponent<TxOutputProps, typeof Card>({
           <HStack align="center" gap="1" className="flex-1 justify-between">
             <Text>Message</Text>
             <VStack gap="1" className="mr-2">
-              <Address value={recipient} linkPos="left">
+              <Address value={recipient || ''} linkPos="left">
                 <Address.Link
                   as={NextLink}
                   href={`/account/${recipient}`}
@@ -149,7 +151,7 @@ const TxOutputMessage = createComponent<TxOutputProps, typeof Card>({
                   Recipient
                 </Address.Link>
               </Address>
-              <Address value={output.to} linkPos="left">
+              <Address value={output.to || ''} linkPos="left">
                 <Address.Link
                   as={NextLink}
                   href={`/account/${output.to}`}

--- a/packages/app/src/systems/Transaction/component/TxScripts/TxScripts.tsx
+++ b/packages/app/src/systems/Transaction/component/TxScripts/TxScripts.tsx
@@ -34,7 +34,8 @@ const ICON_SIZE = 24;
 function parseJson(item: TransactionReceiptFragment): Record<string, any> {
   return Object.entries(item).reduce((acc, [key, value]) => {
     if (!value || key === '__typename') return acc;
-    if (typeof value === 'object') return { ...acc, [key]: parseJson(value) };
+    if (typeof value === 'object')
+      return { ...acc, [key]: parseJson(value as any) };
     return { ...acc, [key]: value };
   }, {});
 }
@@ -44,7 +45,7 @@ export type TxScriptRowProps = BaseProps<{
 }>;
 
 function TxScriptRow({ item }: TxScriptRowProps) {
-  const asset = useAsset(item.assetId);
+  const asset = useAsset(item.assetId || '');
   const classes = styles();
   const amount = bn(item.amount);
   const isDanger =

--- a/packages/graphql/codegen.ts
+++ b/packages/graphql/codegen.ts
@@ -15,6 +15,11 @@ const config: CodegenConfig = {
         nonOptionalTypename: true,
         rawRequest: true,
         useTypeImports: true,
+        defaultScalarType: 'string',
+        scalars: {
+          Boolean: 'boolean',
+          Int: 'number',
+        },
       },
     },
     'src/generated/mocks.ts': {

--- a/packages/graphql/src/domains/Transaction.ts
+++ b/packages/graphql/src/domains/Transaction.ts
@@ -38,7 +38,7 @@ export class TransactionDomain extends Domain<TransactionItemFragment> {
     const { source: transaction } = this;
     const status = transaction.status;
     if (status?.__typename === 'SqueezedOutStatus') return null;
-    const time = status?.time ?? null;
+    const time = status?.time || '';
     const date = tai64toDate(time);
     return {
       fromNow: date.fromNow(),

--- a/packages/ui/src/components/Address/Address.tsx
+++ b/packages/ui/src/components/Address/Address.tsx
@@ -22,7 +22,7 @@ import type { UseFuelAddressOpts } from './useFuelAddress';
 import { useFuelAddress } from './useFuelAddress';
 
 export type AddressBaseProps = {
-  value: string;
+  value?: string;
   prefix?: ReactNode;
   full?: boolean;
   addressOpts?: UseFuelAddressOpts;
@@ -54,7 +54,7 @@ export const AddressRoot = createComponent<AddressProps, typeof HStack>({
   ) => {
     const classes = styles();
     const { isValid, isShowingB256, address, short, toggle } = useFuelAddress(
-      value,
+      value || '',
       { ...addressOpts, fixed },
     );
 


### PR DESCRIPTION
Closes FE-24

Adding `defaultScalarType: string` as most cases will be string:
```
  ID
  String
  Address
  AssetId
  BlockId
  Bytes32
  ContractId
  HexString
  MessageId
  Nonce
  Salt
  Signature
  Tai64Timestamp
  TransactionId
  TxPointer
  U32
  U64
  UtxoId
```

Also adding specific scalar config for:
```
          Boolean: 'boolean',
          Int: 'number',
```