### PR TITLE
feat: make theme configuration work cross applications

### DIFF
--- a/packages/app-explorer/src/systems/Core/components/Provider/Provider.tsx
+++ b/packages/app-explorer/src/systems/Core/components/Provider/Provider.tsx
@@ -1,19 +1,13 @@
 'use client';
 
-import { Theme, Toaster } from '@fuels/ui';
-import { ThemeProvider } from 'next-themes';
+import { Toaster } from '@fuels/ui';
+import { ThemeProvider } from '../Theme';
 
-export function Provider({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export function Provider({ children }: { children: React.ReactNode }) {
   return (
-    <ThemeProvider attribute="class">
-      <Theme hasBackground={false}>
-        {children}
-        <Toaster />
-      </Theme>
+    <ThemeProvider>
+      {children}
+      <Toaster />
     </ThemeProvider>
   );
 }

--- a/packages/app-explorer/src/systems/Core/components/Theme/Theme.tsx
+++ b/packages/app-explorer/src/systems/Core/components/Theme/Theme.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { Theme } from '@fuels/ui';
+import { ThemeProvider as NextThemeProvider } from 'next-themes';
+import { ThemeDefault } from './ThemeDefault';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemeProvider attribute="class" storageKey="fuel-ui-theme">
+      <ThemeDefault />
+      <Theme hasBackground={false}>{children}</Theme>
+    </NextThemeProvider>
+  );
+}

--- a/packages/app-explorer/src/systems/Core/components/Theme/ThemeDefault.tsx
+++ b/packages/app-explorer/src/systems/Core/components/Theme/ThemeDefault.tsx
@@ -1,0 +1,19 @@
+import { useTheme } from 'next-themes';
+import { useEffect } from 'react';
+
+/*
+  This component ensure the theme is saved
+  to storage. Making it available for other applications
+  under the same domain
+*/
+export function ThemeDefault() {
+  const { theme, setTheme } = useTheme();
+
+  useEffect(() => {
+    if (theme === 'system') {
+      setTheme('dark');
+    }
+  }, [theme]);
+
+  return null;
+}

--- a/packages/app-explorer/src/systems/Core/components/Theme/index.tsx
+++ b/packages/app-explorer/src/systems/Core/components/Theme/index.tsx
@@ -1,0 +1,2 @@
+export * from './Theme';
+export * from './ThemeDefault';

--- a/packages/app-explorer/src/systems/Core/components/TopNav/TopNav.tsx
+++ b/packages/app-explorer/src/systems/Core/components/TopNav/TopNav.tsx
@@ -7,9 +7,9 @@ import { useEffect, useState } from 'react';
 import { SearchWidget } from '../Search/SearchWidget';
 
 export function TopNav() {
+  const { theme, setTheme } = useTheme();
   // We need two of each variable bc both the mobile and desktop
   // nav elements are in the DOM and respond to click events.
-  const { setTheme } = useTheme();
   const [isDesktopSearchOpen, setIsDesktopSearchOpen] = useState(false);
   const [isMobileSearchOpen, setIsMobileSearchOpen] = useState(false);
   const { isMobile, isLaptop } = useBreakpoints();
@@ -58,6 +58,7 @@ export function TopNav() {
   const themeToggle = (
     <Nav.ThemeToggle
       whenOpened="no-effect"
+      theme={theme!}
       onToggle={(theme) => setTheme(theme)}
     />
   );

--- a/packages/app-portal/.env.production
+++ b/packages/app-portal/.env.production
@@ -5,4 +5,3 @@ VITE_IS_PUBLIC_PREVIEW=true
 VITE_WALLET_INSTALL=https://chrome.google.com/webstore/detail/fuel-wallet/dldjpboieedgcmpkchcjcbijingjcgok
 VITE_WALLET_INSTALL_NEXT=https://next-wallet.fuel.network/docs/install/#install-from-source-code
 VITE_BLOCK_EXPLORER_URL=https://app.fuel.network/
-VITE_FUEL_PROVIDER_URL=https://beta-5.fuel.network/graphql

--- a/packages/app-portal/src/config.ts
+++ b/packages/app-portal/src/config.ts
@@ -14,11 +14,9 @@ export const {
   VITE_FUEL_FUNGIBLE_ASSET_ID,
   VITE_WALLET_INSTALL,
   VITE_WALLET_INSTALL_NEXT,
-  VITE_FUEL_PROVIDER_URL,
   VITE_BLOCK_EXPLORER_URL,
 } = import.meta.env;
 
-export const FUEL_PROVIDER = VITE_FUEL_PROVIDER_URL;
 export const IS_PREVIEW = import.meta.env.VITE_IS_PUBLIC_PREVIEW === 'true';
 export const IS_DEVELOPMENT = import.meta.env.DEV;
 export const IS_TEST = import.meta.env.MODE === 'test';

--- a/packages/app-portal/src/systems/Bridge/hooks/useExplorerLink.tsx
+++ b/packages/app-portal/src/systems/Bridge/hooks/useExplorerLink.tsx
@@ -1,6 +1,7 @@
 import { buildBlockExplorerUrl } from 'fuels';
 import { useMemo } from 'react';
-import { FUEL_PROVIDER, VITE_BLOCK_EXPLORER_URL } from '~/config';
+import { VITE_BLOCK_EXPLORER_URL } from '~/config';
+import { FUEL_CHAIN } from '~/systems/Chains';
 
 export type ExplorerLinkProps = {
   network: 'ethereum' | 'fuel' | string | undefined;
@@ -17,7 +18,7 @@ export function useExplorerLink({
       return `https://sepolia.etherscan.io/tx/${id}`;
     }
     if (network === 'fuel') {
-      if (providerUrl === FUEL_PROVIDER) {
+      if (providerUrl === FUEL_CHAIN.providerUrl) {
         return `${VITE_BLOCK_EXPLORER_URL}tx/${id}`;
       }
       return buildBlockExplorerUrl({

--- a/packages/app-portal/src/vite-env.d.ts
+++ b/packages/app-portal/src/vite-env.d.ts
@@ -16,7 +16,6 @@ interface ImportMetaEnv {
   readonly VITE_IS_PUBLIC_PREVIEW: string;
   readonly VITE_WALLET_INSTALL: string;
   readonly VITE_WALLET_INSTALL_NEXT: string;
-  readonly VITE_FUEL_PROVIDER_URL: string;
   readonly VITE_BLOCK_EXPLORER_URL: string;
 }
 

--- a/packages/app-portal/vite.config.ts
+++ b/packages/app-portal/vite.config.ts
@@ -5,9 +5,12 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 
 import './load.envs.js';
 
-const { PORT, NODE_ENV, CI } = process.env;
+const { PORT, NO_PORTAL, CI } = process.env;
 
-const basePortal = NODE_ENV === 'production' ? '/portal' : '/';
+// NO_PORTAL can be set on .env for local development
+// directly on the .env file or on the command line
+// to run the app without the /portal prefix
+const basePortal = NO_PORTAL ? '/' : '/portal';
 process.env.BASE_URL = basePortal;
 
 // https://vitejs.dev/config/

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -73,7 +73,6 @@
     "geist": "1.2.2",
     "modern-normalize": "2.0.0",
     "next": "14.1.0",
-    "next-themes": "0.2.1",
     "radix-ui-themes-with-tailwind": "1.2.6",
     "react": "^18.2.0",
     "react-aria": "3.31.1",

--- a/packages/ui/src/components/Nav/Nav.tsx
+++ b/packages/ui/src/components/Nav/Nav.tsx
@@ -9,7 +9,6 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { Children, cloneElement, useEffect, useState } from 'react';
 import { useWindowSize } from 'react-use';
 
-import { useTheme } from 'next-themes';
 import { useStrictedChildren } from '../../hooks/useStrictedChildren';
 import { createComponent, withNamespace } from '../../utils/component';
 import { cx } from '../../utils/css';
@@ -57,6 +56,7 @@ export type NavConnectionProps = HStackProps & {
 export type NavThemeToggleProps = AsChildProp &
   PropsOf<'span'> & {
     whenOpened?: 'hide' | 'show' | 'no-effect';
+    theme: 'dark' | 'light' | string;
     onToggle?: (theme: string) => void;
   };
 
@@ -345,13 +345,15 @@ export const NavConnection = createComponent<NavConnectionProps, typeof Button>(
 export const NavThemeToggle = createComponent<NavThemeToggleProps, 'span'>({
   id: 'NavThemeToggle',
   baseElement: 'span',
-  render: (Root, { className, whenOpened = 'hide', onToggle, ...props }) => {
-    const { theme: current } = useTheme();
+  render: (
+    Root,
+    { className, theme, whenOpened = 'hide', onToggle, ...props },
+  ) => {
     const mobileProps = useNavMobileContext();
     const classes = styles();
 
     function handleToggle() {
-      const next = current === 'light' ? 'dark' : 'light';
+      const next = theme === 'light' ? 'dark' : 'light';
       onToggle?.(next);
     }
 
@@ -360,7 +362,7 @@ export const NavThemeToggle = createComponent<NavThemeToggleProps, 'span'>({
         {...props}
         aria-label="Toggle Theme"
         className={classes.themeToggle({ className })}
-        data-theme={current}
+        data-theme={theme}
         role="button"
         tabIndex={0}
         onClick={handleToggle}

--- a/packages/ui/src/components/Nav/Nav.tsx
+++ b/packages/ui/src/components/Nav/Nav.tsx
@@ -56,7 +56,7 @@ export type NavConnectionProps = HStackProps & {
 export type NavThemeToggleProps = AsChildProp &
   PropsOf<'span'> & {
     whenOpened?: 'hide' | 'show' | 'no-effect';
-    theme: 'dark' | 'light' | string;
+    theme?: 'dark' | 'light' | string;
     onToggle?: (theme: string) => void;
   };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,9 +856,6 @@ importers:
       next:
         specifier: 14.1.0
         version: 14.1.0(@babel/core@7.23.9)(react-dom@18.2.0)(react@18.2.0)
-      next-themes:
-        specifier: 0.2.1
-        version: 0.2.1(next@14.1.0)(react-dom@18.2.0)(react@18.2.0)
       radix-ui-themes-with-tailwind:
         specifier: 1.2.6
         version: 1.2.6
@@ -28054,7 +28051,7 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.0.1(typescript@5.3.3)
-      vite: 5.0.12(@types/node@20.11.16)
+      vite: 5.0.12(@types/node@20.11.6)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
On this PR;
- Add a force component that setTheme if undefined to ensure the theme is on localStorage
- Once theme on storage changes both application receive the new theme
- Remove the need for next-themes inside `@fuels/ui`