### PR TITLE
fix: connect wallet before confirm if not connected

### DIFF
--- a/packages/app-portal/src/systems/Chains/eth/hooks/useEthAccountConnection.tsx
+++ b/packages/app-portal/src/systems/Chains/eth/hooks/useEthAccountConnection.tsx
@@ -10,11 +10,14 @@ import {
 } from 'wagmi';
 import type { AssetEth } from '~/systems/Assets/utils';
 
+import { useEffect } from 'react';
+import { useOverlay } from '~/systems/Overlay';
 import { parseEthAddressToFuel } from '../utils';
 
 export function useEthAccountConnection(props?: {
   erc20Address?: `0x${string}`;
 }) {
+  const overlay = useOverlay();
   const { erc20Address } = props || {};
   const { address, isConnected } = useAccount();
   const { data: ensName } = useEnsName({ address });
@@ -30,6 +33,10 @@ export function useEthAccountConnection(props?: {
   const { disconnect } = useDisconnect();
   const paddedAddress = parseEthAddressToFuel(address);
 
+  useEffect(() => {
+    overlay.settings.closeOnBlur = !isConnecting;
+  }, [isConnecting]);
+
   async function addAsset(asset: AssetEth) {
     if (asset.address && walletClient) {
       await walletClient?.watchAsset({
@@ -43,9 +50,14 @@ export function useEthAccountConnection(props?: {
     }
   }
 
+  function connect() {
+    overlay.settings.closeOnBlur = false;
+    setOpen(true);
+  }
+
   return {
     handlers: {
-      connect: () => setOpen(true),
+      connect,
       disconnect,
       addAsset,
     },

--- a/packages/app-portal/src/systems/Chains/fuel/containers/TxFuelToEthDialog.tsx
+++ b/packages/app-portal/src/systems/Chains/fuel/containers/TxFuelToEthDialog.tsx
@@ -5,11 +5,17 @@ import { BridgeSteps, BridgeTxOverview } from '~/systems/Bridge';
 import { shortAddress } from '~/systems/Core';
 import { useOverlay } from '~/systems/Overlay';
 
+import { useEthAccountConnection } from '../../eth';
 import { useTxFuelToEth } from '../hooks';
 
 export function TxFuelToEthDialog() {
   const { asset: ethAsset } = useAsset();
   const { metadata } = useOverlay<{ txId: string }>();
+  const {
+    isConnected,
+    isConnecting,
+    handlers: ethHandlers,
+  } = useEthAccountConnection();
   const {
     steps,
     status,
@@ -50,14 +56,25 @@ export function TxFuelToEthDialog() {
       {(status?.isWaitingEthWalletApproval ||
         status?.isConfirmTransactionLoading) && (
         <Dialog.Footer>
-          <Button
-            intent="primary"
-            css={styles.actionButton}
-            isLoading={status.isConfirmTransactionLoading}
-            onClick={handlers.relayToEth}
-          >
-            Confirm Transaction
-          </Button>
+          {isConnected ? (
+            <Button
+              intent="primary"
+              css={styles.actionButton}
+              isLoading={status.isConfirmTransactionLoading}
+              onClick={handlers.relayToEth}
+            >
+              Confirm Transaction
+            </Button>
+          ) : (
+            <Button
+              intent="primary"
+              css={styles.actionButton}
+              isLoading={isConnecting}
+              onClick={ethHandlers.connect}
+            >
+              Connect Ethereum Wallet
+            </Button>
+          )}
         </Dialog.Footer>
       )}
     </>

--- a/packages/app-portal/src/systems/Overlay/components/OverlayDialog/OverlayDialog.tsx
+++ b/packages/app-portal/src/systems/Overlay/components/OverlayDialog/OverlayDialog.tsx
@@ -18,6 +18,7 @@ export function OverlayDialog() {
     <Dialog
       isOpen={overlay.isDialogOpen}
       css={styles.dialog}
+      shouldCloseOnInteractOutside={() => overlay.settings.closeOnBlur}
       onOpenChange={(isOpen) => !isOpen && overlay.close()}
     >
       <Dialog.Content css={styles.content}>

--- a/packages/app-portal/src/systems/Overlay/hooks/useOverlay.tsx
+++ b/packages/app-portal/src/systems/Overlay/hooks/useOverlay.tsx
@@ -15,6 +15,10 @@ const selectors = {
   },
 };
 
+const settings = {
+  closeOnBlur: true,
+};
+
 export function useOverlay<T = void>() {
   const isDialogOpen = store.useSelector(
     Services.overlay,
@@ -31,6 +35,7 @@ export function useOverlay<T = void>() {
     is,
     isDialogOpen,
     overlay,
+    settings,
     metadata: metadata as T,
     open: store.openOverlay,
     close: store.closeOverlay,


### PR DESCRIPTION
On this PR;
- Add a setting configuration object to pass data around overlay action this is required to pass the data at the time Dialog should close check happens.
- This solves the issue where user is required to confirm TX but ETH Wallet is not connected. Creating the flow of asking first to connect, and them keeping the user on the screen to finish the action.