### PR TITLE
feat: migrate InputAmount

### DIFF
--- a/packages/app-explorer/tsconfig.json
+++ b/packages/app-explorer/tsconfig.json
@@ -4,7 +4,7 @@
     "plugins": [{ "name": "next" }],
     "allowJs": true,
     "noEmit": true,
-    "lib": ["dom"],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "incremental": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/packages/app-portal/src/systems/Bridge/pages/Bridge.tsx
+++ b/packages/app-portal/src/systems/Bridge/pages/Bridge.tsx
@@ -8,8 +8,7 @@ import {
   useFuelAccountConnection,
 } from '~/systems/Chains';
 
-import { InputAmount } from '@fuel-ui/react';
-import { Alert, Box, Card, Link, Text, VStack } from '@fuels/ui';
+import { Alert, Box, Card, InputAmount, Link, Text, VStack } from '@fuels/ui';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { tv } from 'tailwind-variants';
 import { BridgeButton, BridgeTabs } from '../containers';

--- a/packages/app-portal/src/systems/Core/components/Header.tsx
+++ b/packages/app-portal/src/systems/Core/components/Header.tsx
@@ -3,7 +3,6 @@ import { NavLink } from 'react-router-dom';
 import { Pages } from '~/types';
 
 import { tv } from 'tailwind-variants';
-import { removeTrailingSlash } from '../utils';
 
 export function Header() {
   const classes = styles();

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -78,6 +78,7 @@
     "react": "^18.2.0",
     "react-aria": "3.31.1",
     "react-dom": "^18.2.0",
+    "react-number-format": "5.3.1",
     "react-stately": "3.29.1",
     "react-use": "17.5.0",
     "tailwind-merge": "2.2.1",

--- a/packages/ui/src/components/Collapsible/Collapsible.tsx
+++ b/packages/ui/src/components/Collapsible/Collapsible.tsx
@@ -13,6 +13,8 @@ import type { CardBodyProps, CardHeaderProps, CardProps } from '../Card';
 import { IconButton } from '../IconButton';
 import { Text } from '../Text';
 
+import { WithIconProps } from '../../hooks/useIconProps';
+
 type CollapsibleBaseProps = VariantProps<typeof styles> & {
   defaultOpened?: boolean;
   opened?: boolean;
@@ -32,7 +34,7 @@ export type CollapsibleProps = CollapsibleBaseProps &
   CardProps & { hideIcon?: boolean };
 export type CollapsibleHeaderProps = CardHeaderProps;
 export type CollapsibleContentProps = CardBodyProps;
-export type CollapsibleTitleProps = TextProps;
+export type CollapsibleTitleProps = TextProps & WithIconProps;
 export type CollapsibleBodyProps = BoxProps;
 
 export const CollapsibleRoot = createComponent<CollapsibleProps, typeof Card>({

--- a/packages/ui/src/components/Input/Input.tsx
+++ b/packages/ui/src/components/Input/Input.tsx
@@ -1,11 +1,15 @@
 import { TextField as RT } from '@radix-ui/themes';
 
+import { NumericFormat } from 'react-number-format';
+import type { NumericFormatProps } from 'react-number-format';
+
 import { createComponent, withNamespace } from '../../utils/component';
 import type { PropsOf } from '../../utils/types';
 
 export type InputProps = PropsOf<typeof RT.Root>;
 export type InputSlotProps = PropsOf<typeof RT.Slot>;
 export type InputFieldProps = PropsOf<typeof RT.Input>;
+export type InputNumberProps = Omit<NumericFormatProps, 'color' | 'size'>;
 
 export const InputRoot = createComponent<InputProps, typeof RT.Root>({
   id: 'Input',
@@ -22,7 +26,19 @@ export const InputField = createComponent<InputFieldProps, typeof RT.Input>({
   baseElement: RT.Input,
 });
 
+export const InputNumber = createComponent<
+  InputNumberProps,
+  typeof NumericFormat
+>({
+  id: 'InputNumber',
+  baseElement: NumericFormat,
+  render: (Root, props) => {
+    return <Root {...props} customInput={InputField} />;
+  },
+});
+
 export const Input = withNamespace(InputRoot, {
   Slot: InputSlot,
   Field: InputField,
+  Number: InputNumber,
 });

--- a/packages/ui/src/components/Input/index.tsx
+++ b/packages/ui/src/components/Input/index.tsx
@@ -1,3 +1,3 @@
-export { Input, InputField, InputRoot, InputSlot } from './Input';
+export { Input, InputField, InputNumber, InputRoot, InputSlot } from './Input';
 
 export type { InputFieldProps, InputProps, InputSlotProps } from './Input';

--- a/packages/ui/src/components/InputAmount/InputAmount.tsx
+++ b/packages/ui/src/components/InputAmount/InputAmount.tsx
@@ -81,11 +81,18 @@ export const InputAmount = ({
       variant={variant}
     >
       <Flex>
-        <Input.Field
+        <Input.Number
           autoComplete="off"
           inputMode="decimal"
           placeholder="0.00"
+          allowedDecimalSeparators={['.', ',']}
+          allowNegative={false}
+          thousandSeparator={false}
           value={assetAmount}
+          onChange={(e) => {
+            handleAmountChange(e.target.value);
+          }}
+          decimalScale={DECIMAL_UNITS}
         />
 
         <Input.Slot>

--- a/packages/ui/src/components/InputAmount/InputAmount.tsx
+++ b/packages/ui/src/components/InputAmount/InputAmount.tsx
@@ -89,7 +89,7 @@ export const InputAmount = ({
           allowNegative={false}
           thousandSeparator={false}
           value={assetAmount}
-          onChange={(e) => {
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
             handleAmountChange(e.target.value);
           }}
           decimalScale={DECIMAL_UNITS}

--- a/packages/ui/src/components/InputAmount/InputAmount.tsx
+++ b/packages/ui/src/components/InputAmount/InputAmount.tsx
@@ -82,6 +82,7 @@ export const InputAmount = ({
     >
       <Flex>
         <Input.Number
+          className="p-0.5 font-mono text-lg"
           autoComplete="off"
           inputMode="decimal"
           placeholder="0.00"
@@ -95,11 +96,13 @@ export const InputAmount = ({
           decimalScale={DECIMAL_UNITS}
         />
 
-        <Input.Slot>
+        <Input.Slot gap="4">
           <Button
             aria-label="Max"
             variant="link"
             size="1"
+            color="green"
+            className="font-mono"
             onClick={handleSetBalance}
           >
             MAX
@@ -108,34 +111,36 @@ export const InputAmount = ({
             <Button
               aria-label="Coin Selector"
               variant="outline"
+              color="gray"
+              className="gap-1.5 text-xs py-1 px-2"
               onClick={onClickAsset}
               disabled={!onClickAsset}
-              size="2"
             >
               <Avatar
                 src={asset?.imageUrl}
                 fallback=""
                 radius="full"
-                size="1"
+                className="w-5 h-5"
               />
 
               {asset.name}
-              <Icon color="text-green-10" icon={IconChevronDown} size={16} />
+              <IconChevronDown height={20} width={20} />
             </Button>
           )}
         </Input.Slot>
       </Flex>
 
-      <Tooltip content={format(balance, formatOpts)} sideOffset={-5}>
-        <Text
-          size="2"
-          color="blue"
-          className="pl-2 pb-2 self-start"
-          aria-label={`Balance: ${formattedBalance}`}
-        >
-          Balance: {formattedBalance}
-        </Text>
-      </Tooltip>
+      <Input.Slot>
+        <Tooltip content={format(balance, formatOpts)} sideOffset={-5}>
+          <Text
+            size="1"
+            className="pb-3 self-start"
+            aria-label={`Balance: ${formattedBalance}`}
+          >
+            Balance: {formattedBalance}
+          </Text>
+        </Tooltip>
+      </Input.Slot>
     </Input>
   );
 };

--- a/packages/ui/src/components/InputAmount/InputAmount.tsx
+++ b/packages/ui/src/components/InputAmount/InputAmount.tsx
@@ -89,7 +89,7 @@ export const InputAmount = ({
           allowNegative={false}
           thousandSeparator={false}
           value={assetAmount}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+          onChange={(e) => {
             handleAmountChange(e.target.value);
           }}
           decimalScale={DECIMAL_UNITS}

--- a/packages/ui/src/components/InputAmount/InputAmount.tsx
+++ b/packages/ui/src/components/InputAmount/InputAmount.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from 'react';
+
+import { type BN, FormatConfig, bn, format } from '@fuel-ts/math';
+import { DECIMAL_UNITS, DEFAULT_MIN_PRECISION } from '@fuel-ts/math/configs';
+
+import { IconChevronDown } from '@tabler/icons-react';
+
+import { cx } from '../../utils/css';
+import { Flex } from '../Box';
+import { Button } from '../Button';
+import { Icon } from '../Icon';
+import type { InputProps } from '../Input/Input';
+import { Input } from '../Input/Input';
+import { Text } from '../Text';
+import { Tooltip } from '../Tooltip';
+
+import { Avatar } from '../Avatar';
+import { createAmount } from './utils';
+
+export type InputAmountProps = Omit<InputProps, 'size' | 'onChange'> & {
+  isDisabled?: boolean;
+  balance?: BN;
+  asset?: { name?: string; imageUrl?: string; address?: string };
+  value?: BN | null;
+  onChange?: (val: BN | null) => void;
+  onClickAsset?: () => void;
+};
+
+const formatOpts: FormatConfig = {
+  units: DECIMAL_UNITS,
+  precision: DECIMAL_UNITS,
+};
+
+export const InputAmount = ({
+  className,
+  variant,
+  color,
+  value,
+  balance: initialBalance,
+  asset,
+  onChange,
+  onClickAsset,
+}: InputAmountProps) => {
+  const [assetAmount, setAssetAmount] = useState<string>(
+    !value || value.eq(0) ? '' : value.format(formatOpts),
+  );
+
+  const balance = initialBalance ?? bn(initialBalance);
+  const formattedBalance = balance.format({
+    ...formatOpts,
+    precision: balance.eq(0) ? 1 : DEFAULT_MIN_PRECISION,
+  });
+
+  const handleAmountChange = (text: string) => {
+    const { text: newText, amount } = createAmount(text, formatOpts.units);
+    const { amount: currentAmount } = createAmount(
+      assetAmount,
+      formatOpts.units,
+    );
+    if (!currentAmount.eq(amount)) {
+      onChange?.(newText.length ? amount : null);
+      setAssetAmount(newText);
+    }
+  };
+
+  const handleSetBalance = () => {
+    if (balance) {
+      handleAmountChange(balance.format(formatOpts));
+    }
+  };
+
+  useEffect(() => {
+    handleAmountChange(value ? value.format(formatOpts) : '');
+  }, [value?.toString()]);
+
+  return (
+    <Input
+      className={cx(className, 'flex-col')}
+      color={color}
+      size="3"
+      variant={variant}
+    >
+      <Flex>
+        <Input.Field
+          autoComplete="off"
+          inputMode="decimal"
+          placeholder="0.00"
+          value={assetAmount}
+        />
+
+        <Input.Slot>
+          <Button
+            aria-label="Max"
+            variant="link"
+            size="1"
+            onClick={handleSetBalance}
+          >
+            MAX
+          </Button>
+          {asset && (
+            <Button
+              aria-label="Coin Selector"
+              variant="outline"
+              onClick={onClickAsset}
+              disabled={!onClickAsset}
+              size="2"
+            >
+              <Avatar
+                src={asset?.imageUrl}
+                fallback=""
+                radius="full"
+                size="1"
+              />
+
+              {asset.name}
+              <Icon color="text-green-10" icon={IconChevronDown} size={16} />
+            </Button>
+          )}
+        </Input.Slot>
+      </Flex>
+
+      <Tooltip content={format(balance, formatOpts)} sideOffset={-5}>
+        <Text
+          size="2"
+          color="blue"
+          className="pl-2 pb-2 self-start"
+          aria-label={`Balance: ${formattedBalance}`}
+        >
+          Balance: {formattedBalance}
+        </Text>
+      </Tooltip>
+    </Input>
+  );
+};

--- a/packages/ui/src/components/InputAmount/index.ts
+++ b/packages/ui/src/components/InputAmount/index.ts
@@ -1,0 +1,5 @@
+'use client';
+
+export { InputAmount } from './InputAmount';
+
+export type { InputAmountProps } from './InputAmount';

--- a/packages/ui/src/components/InputAmount/utils.ts
+++ b/packages/ui/src/components/InputAmount/utils.ts
@@ -1,0 +1,25 @@
+import { bn } from '@fuel-ts/math';
+import { DECIMAL_UNITS } from '@fuel-ts/math/configs';
+
+export function formatAmountLeadingZeros(text: string): string {
+  const valueWithoutLeadingZeros = text
+    .replace(/^0\d/, (substring) => substring.replace(/^0+(?=[\d])/, ''))
+    .replace(/^0+(\d\.)/, '$1');
+  const startsWithPoint = valueWithoutLeadingZeros.startsWith('.');
+
+  if (!startsWithPoint) {
+    return valueWithoutLeadingZeros;
+  }
+  if (valueWithoutLeadingZeros.length < 3) {
+    return `0${valueWithoutLeadingZeros}`;
+  }
+  return text;
+}
+
+export function createAmount(text: string, units: number = DECIMAL_UNITS) {
+  const textAmountFixed = formatAmountLeadingZeros(text);
+  return {
+    text: textAmountFixed,
+    amount: bn.parseUnits(text.replaceAll(',', ''), units),
+  };
+}

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -36,6 +36,7 @@ export * from './components/HoverCard';
 export * from './components/Icon';
 export * from './components/IconButton';
 export * from './components/Input';
+export * from './components/InputAmount';
 export * from './components/InputPassword';
 export * from './components/Inset';
 export * from './components/Link';

--- a/packages/ui/src/utils/component.tsx
+++ b/packages/ui/src/utils/component.tsx
@@ -9,10 +9,7 @@ import type {
   PropsOf,
   WithAsProps,
 } from './types';
-type CreateOpts<
-  P extends PropsOf<any>,
-  C extends ComponentType<any> | ElementType<any>,
-> = {
+type CreateOpts<P extends PropsOf<any>, C extends ElementType<any>> = {
   id: string;
   baseElement?: C;
   className?: string | ((props: P) => string);
@@ -22,24 +19,27 @@ type CreateOpts<
 
 export function createComponent<
   P extends PropsOf<any>,
-  C extends ComponentType<any> | ElementType<any>,
+  C extends ElementType<any>,
 >(opts: CreateOpts<P, C>) {
-  const { id, baseElement: El = 'div', className: getClass, render } = opts;
+  const {
+    id,
+    baseElement: El = 'div' as C,
+    className: getClass,
+    render,
+  } = opts;
 
   if (!El && !render) {
     throw new Error('Must provide either baseElement or render');
   }
 
   type T = ElementRef<typeof El>;
-  const Comp = forwardRef<T, P & PropsOf<typeof El>>(
-    ({ className, ...props }, ref) => {
-      const baseClass =
-        typeof getClass === 'function' ? getClass(props as P) : getClass;
-      const classes = cx(baseClass, className, fClass(id));
-      const itemProps = { ref, className: classes, ...props } as any;
-      return render ? render(El as C, itemProps) : <El {...itemProps} />;
-    },
-  );
+  const Comp = forwardRef<T, P>(({ className, ...props }, ref) => {
+    const baseClass =
+      typeof getClass === 'function' ? getClass(props as P) : getClass;
+    const classes = cx(baseClass, className, fClass(id));
+    const itemProps = { ref, className: classes, ...props } as any;
+    return render ? render(El, itemProps) : <El {...itemProps} />;
+  });
 
   if (opts.defaultProps) {
     Comp.defaultProps = opts.defaultProps;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -898,6 +898,9 @@ importers:
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
+      react-number-format:
+        specifier: 5.3.1
+        version: 5.3.1(react-dom@18.2.0)(react@18.2.0)
       react-stately:
         specifier: 3.29.1
         version: 3.29.1(react@18.2.0)
@@ -4800,11 +4803,6 @@ packages:
     resolution: {integrity: sha512-GZ/NxWEHfGjvUq6ipM/BMfLt9n4jabZPEkJSQiJvmPrq2Dvp/TOEESfw5s+CdH3/hjf/T9imMekhHphZvl7RnQ==}
     peerDependencies:
       jest: ^29.6.4
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
     dependencies:
       '@ariakit/test': 0.2.5(@testing-library/dom@9.3.4)(@testing-library/react@14.2.1)(react@18.2.0)
       '@chakra-ui/utils': 2.0.15
@@ -14383,9 +14381,6 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
-    peerDependenciesMeta:
-      ajv:
-        optional: true
     dependencies:
       ajv: 8.12.0
     dev: true
@@ -17844,7 +17839,6 @@ packages:
       is-hex-prefixed: 1.0.0
       strip-hex-prefix: 1.0.0
     dev: false
-    bundledDependencies: false
 
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
@@ -27812,7 +27806,7 @@ packages:
       debug: 4.3.4(supports-color@5.5.0)
       globrex: 0.1.2
       tsconfck: 3.0.1(typescript@5.3.3)
-      vite: 5.0.12(@types/node@20.11.6)
+      vite: 5.0.12(@types/node@20.11.16)
     transitivePeerDependencies:
       - supports-color
       - typescript


### PR DESCRIPTION
Migrate `InputAmount` from `@fuel-ui/design-system` and replacing `stitches` with `tailwind`.

| 📷 Demo |
|--------|
| <video src="https://github.com/FuelLabs/fuel-explorer/assets/7074983/47838fa7-affc-4cc2-832b-5a4a6ceb7936" /> |

