### PR TITLE
fix: ensure order of build and complete output paths

### DIFF
--- a/packages/app-explorer/package.json
+++ b/packages/app-explorer/package.json
@@ -44,7 +44,8 @@
     "tailwind-merge": "2.2.1",
     "tailwind-variants": "0.1.20",
     "zod": "3.22.4",
-    "zod-validation-error": "3.0.0"
+    "zod-validation-error": "3.0.0",
+    "app-portal": "workspace:*"
   },
   "devDependencies": {
     "@babel/core": "^7.23.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       '@vercel/analytics':
         specifier: 1.1.3
         version: 1.1.3
+      app-portal:
+        specifier: workspace:*
+        version: link:../app-portal
       clsx:
         specifier: 2.1.0
         version: 2.1.0

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,14 @@
       "cache": true
     },
     "build:preview": {
-      "outputs": ["public/**", "dist/**", "build/**", ".next/**"],
+      "outputs": [
+        "app-explorer/public/portal/**",
+        "app-explorer/public/ui/**",
+        "dist/**",
+        "build/**",
+        ".next/**",
+        "public/**"
+      ],
       "dependsOn": ["^build"],
       "cache": true
     },


### PR DESCRIPTION
Ensure app-explorer is built after app-portal has finish the build process by adding a dependency on package.json, also adds the completely path of the outputs on turbo.json to avoid incorrect cache.