### PR TITLE
fix: resolve html hydration issue

### DIFF
--- a/packages/app-explorer/src/systems/Core/components/TopNav/TopNav.tsx
+++ b/packages/app-explorer/src/systems/Core/components/TopNav/TopNav.tsx
@@ -72,11 +72,7 @@ export function TopNav() {
   );
 
   const themeToggle = (
-    <Nav.ThemeToggle
-      whenOpened="no-effect"
-      theme={theme!}
-      onToggle={(theme) => setTheme(theme)}
-    />
+    <Nav.ThemeToggle whenOpened="no-effect" theme={theme} onToggle={setTheme} />
   );
 
   return (

--- a/packages/ui/src/components/Nav/Nav.tsx
+++ b/packages/ui/src/components/Nav/Nav.tsx
@@ -363,7 +363,6 @@ export const NavThemeToggle = createComponent<NavThemeToggleProps, 'span'>({
         {...props}
         aria-label="Toggle Theme"
         className={classes.themeToggle({ className })}
-        data-theme={theme}
         role="button"
         tabIndex={0}
         onClick={handleToggle}


### PR DESCRIPTION
Removes an unused `data-theme` that was firing a hydration error.

<img width="613" alt="Screenshot 2024-02-27 at 11 56 15" src="https://github.com/FuelLabs/fuel-explorer/assets/7074983/33ae207d-5f45-4a5d-a81f-1fa595def57d">
