### PR TITLE
fix: resolve window stringify

### DIFF
--- a/packages/app-portal/src/systems/Chains/eth/hooks/useTxEthToFuel.tsx
+++ b/packages/app-portal/src/systems/Chains/eth/hooks/useTxEthToFuel.tsx
@@ -1,4 +1,3 @@
-import type { Account as FuelWallet } from 'fuels';
 import { useMemo } from 'react';
 import { Services, store } from '~portal/store';
 import { getAssetEth, getAssetFuel } from '~portal/systems/Assets/utils';
@@ -9,6 +8,8 @@ import { useAsset } from '../../../Assets/hooks/useAsset';
 import { useFuelAccountConnection } from '../../fuel';
 import type { TxEthToFuelMachineState } from '../machines';
 import { isErc20Address } from '../utils';
+
+import { deepCompare } from '../utils/deepCompare';
 
 const bridgeTxsSelectors = {
   txEthToFuel: (txId?: `0x${string}`) => (state: BridgeTxsMachineState) => {
@@ -122,6 +123,7 @@ export function useTxEthToFuel({ id }: { id: string }) {
   const txEthToFuelState = store.useSelector(
     Services.bridgeTxs,
     bridgeTxsSelectors.txEthToFuel(txId),
+    deepCompare,
   );
 
   const {
@@ -172,8 +174,7 @@ export function useTxEthToFuel({ id }: { id: string }) {
 
     store.relayMessageEthToFuel({
       input: {
-        // TODO: remove this workaround when we get versions organized and using the same version
-        fuelWallet: fuelWallet as unknown as FuelWallet,
+        fuelWallet,
       },
       ethTxId,
     });

--- a/packages/app-portal/src/systems/Chains/eth/utils/deepCompare.ts
+++ b/packages/app-portal/src/systems/Chains/eth/utils/deepCompare.ts
@@ -1,0 +1,21 @@
+import { Fuel } from 'fuels';
+
+export function deepCompare<T>(a: T, b: T) {
+  if (typeof a === 'object') {
+    return JSON.stringify(a, stringify) === JSON.stringify(b, stringify);
+  }
+
+  return a === b;
+}
+
+function stringify<T>(_key: string, value: T) {
+  if (value instanceof Fuel) {
+    return value.currentConnector()?.name;
+  }
+
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  return value;
+}


### PR DESCRIPTION
Fix the comparison that was crashing the xstate selector because of a `Window` instance inside the `Fuel` class.