### PR TITLE
fix: return only valid links

### DIFF
--- a/packages/app-commons/src/config.ts
+++ b/packages/app-commons/src/config.ts
@@ -10,8 +10,6 @@ export const WALLET_INSTALL = process.env.NEXT_PUBLIC_WALLET_INSTALL;
 export const WALLET_INSTALL_NEXT = process.env.NEXT_PUBLIC_WALLET_INSTALL_NEXT;
 export const NODE_ENV = process.env.NODE_ENV;
 
-export const BLOCK_EXPLORER_URL = process.env.NEXT_PUBLIC_BLOCK_EXPLORER_URL;
-
 export const IS_PREVIEW = process.env.NEXT_PUBLIC_IS_PUBLIC_PREVIEW === 'true';
 export const IS_DEVELOPMENT = process.env.NODE_ENV === 'development';
 

--- a/packages/app-portal/src/systems/Bridge/hooks/useExplorerLink.tsx
+++ b/packages/app-portal/src/systems/Bridge/hooks/useExplorerLink.tsx
@@ -1,30 +1,35 @@
-import { BLOCK_EXPLORER_URL, FUEL_CHAIN } from 'app-commons';
+import { FUEL_CHAIN } from 'app-commons';
 import { buildBlockExplorerUrl } from 'fuels';
 import { useMemo } from 'react';
 
 export type ExplorerLinkProps = {
-  network: 'ethereum' | 'fuel' | string | undefined;
+  network: 'ethereum' | 'fuel';
   providerUrl?: string;
-  id?: string;
+  id: string;
 };
+
 export function useExplorerLink({
   network,
   providerUrl,
   id,
 }: ExplorerLinkProps) {
-  const href = useMemo(() => {
+  const href = useMemo<string>(() => {
     if (network === 'ethereum') {
       return `https://sepolia.etherscan.io/tx/${id}`;
     }
+
     if (network === 'fuel') {
       if (providerUrl === FUEL_CHAIN.providerUrl) {
-        return `${BLOCK_EXPLORER_URL}tx/${id}`;
+        return `/tx/${id}`;
       }
+
       return buildBlockExplorerUrl({
-        path: `transaction/${id || ''}`,
+        path: `transaction/${id}`,
         providerUrl,
       });
     }
+
+    return '';
   }, [network, providerUrl, id]);
 
   return {

--- a/packages/app-portal/src/systems/Chains/eth/hooks/useTxEthToFuel.tsx
+++ b/packages/app-portal/src/systems/Chains/eth/hooks/useTxEthToFuel.tsx
@@ -117,7 +117,7 @@ export function useTxEthToFuel({ id }: { id: string }) {
   const txId = id.startsWith('0x') ? (id as `0x${string}`) : undefined;
   const { href: explorerLink } = useExplorerLink({
     network: 'ethereum',
-    id: txId,
+    id,
   });
 
   const txEthToFuelState = store.useSelector(

--- a/packages/app-portal/src/systems/Chains/fuel/hooks/useTxFuelToEth.tsx
+++ b/packages/app-portal/src/systems/Chains/fuel/hooks/useTxFuelToEth.tsx
@@ -191,7 +191,7 @@ export function useTxFuelToEth({ txId }: { txId: string }) {
   const { assets } = useAssets();
   const { href: explorerLink } = useExplorerLink({
     network: 'fuel',
-    providerUrl: fuelProvider?.url || '',
+    providerUrl: fuelProvider?.url,
     id: txId,
   });
 


### PR DESCRIPTION
Remove unused environment variable that was sending the user to an `undefined` path.