### PR TITLE
fix: revert changes on providerUrl config

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -30,4 +30,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           image: ghcr.io/fuellabs/fuel-explorer
           dockerfile: deployment/Dockerfile
-          context: .
+          context: ./packages/graphql

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
   },
   "tailwindCSS.experimental.classRegex": [
     ["tv\\(([^)]*)\\)", "[\"'`]([^\"'`]*).*?[\"'`]"]
-  ]
+  ],
+  "[javascript]": {
+    "editor.defaultFormatter": "biomejs.biome"
+  }
 }

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -4,7 +4,7 @@ FROM node:20-slim AS base
 
 # Expose the ENVs to the env of the container
 ENV PORT="${PORT}"
-ENV NEXT_PUBLIC_FUEL_CHAIN_NAME="${NEXT_PUBLIC_FUEL_CHAIN_NAME:-fuelBeta5}"
+ENV FUEL_PROVIDER="${FUEL_PROVIDER:-https://beta-5.fuel.network/graphql}"
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 ENV SERVER_BUILD=true
@@ -13,9 +13,8 @@ ENV SERVER_BUILD=true
 RUN corepack enable
 
 # Install dependencies for the entire monorepo
-COPY packages/app-commons ./packages/app-commons
-COPY packages/graphql ./packages/graphql
-COPY package.json turbo.json pnpm-workspace.yaml ./
+COPY . /app-explorer
+WORKDIR /app-explorer
 
 # Install dependencies for the entire monorepo
 RUN pnpm install
@@ -24,5 +23,5 @@ RUN pnpm install
 EXPOSE ${PORT}
 
 # Start GraphQL server
-WORKDIR /packages/graphql
+WORKDIR /app-explorer
 CMD ["pnpm", "server:start"]

--- a/packages/graphql/.env.example
+++ b/packages/graphql/.env.example
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_FUEL_CHAIN_NAME=fuelBeta5 # options: fuelDev, fuelBeta5Dev, fuelBeta5
+FUEL_PROVIDER=http://beta-5.fuel.network/graphql
 SERVER_PORT=4444

--- a/packages/graphql/.env.production
+++ b/packages/graphql/.env.production
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_FUEL_CHAIN_NAME=fuelBeta5 # options: fuelDev, fuelBeta5Dev, fuelBeta5
+FUEL_PROVIDER=http://beta-5.fuel.network/graphql
 SERVER_PORT=4444

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -12,7 +12,7 @@ pnpm dev
 
 ```
 docker run \
-  -e NEXT_PUBLIC_FUEL_CHAIN_NAME=fuelBeta5 \
+  -e FUEL_PROVIDER=http://beta-5.fuel.network/graphql \
   -e SERVER_PORT=3000 \
   -p 3333:3000 \
   ghcr.io/fuellabs/fuel-explorer:main

--- a/packages/graphql/codegen.fuel.ts
+++ b/packages/graphql/codegen.fuel.ts
@@ -1,13 +1,14 @@
 import type { CodegenConfig } from '@graphql-codegen/cli';
+import { requireEnv } from './src/utils/requireEnv';
 
-import { FUEL_CHAIN } from 'app-commons/src/chains/fuel';
-
-const { providerUrl } = FUEL_CHAIN;
+const { FUEL_PROVIDER } = requireEnv([
+  ['FUEL_PROVIDER', 'https://beta-5.fuel.network/graphql'],
+]);
 
 const config: CodegenConfig = {
   generates: {
     './src/schemas/fuelcore.graphql': {
-      schema: providerUrl,
+      schema: FUEL_PROVIDER,
       plugins: ['schema-ast'],
       config: {
         includeDirectives: true,

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -27,7 +27,6 @@
     "@graphql-tools/stitch": "^9.0.3",
     "@graphql-tools/utils": "^10.0.13",
     "@luckycatfactory/esbuild-graphql-loader": "3.8.1",
-    "app-commons": "workspace:*",
     "chokidar": "3.5.3",
     "cors": "^2.8.5",
     "dayjs": "1.11.10",

--- a/packages/graphql/src/process.env.d.ts
+++ b/packages/graphql/src/process.env.d.ts
@@ -1,7 +1,7 @@
 declare global {
   namespace NodeJS {
     interface ProcessEnv {
-      NEXT_PUBLIC_FUEL_CHAIN_NAME: 'fuelDev' | 'fuelBeta5' | 'fuelBeta5Dev';
+      FUEL_PROVIDER?: string;
       SERVER_BUILD?: 'true' | 'false';
       FUEL_EXPLORER_API_KEY?: string;
     }

--- a/packages/graphql/src/server.ts
+++ b/packages/graphql/src/server.ts
@@ -3,13 +3,14 @@ import express from 'express';
 import { createHandler } from 'graphql-http/lib/use/express';
 import expressPlayground from 'graphql-playground-middleware-express';
 
-import { FUEL_CHAIN } from 'app-commons';
 import { ContextDomain } from './domains/Context';
 import { createSchema } from './schema';
 import { createGraphqlFetch } from './utils/executor';
+import { requireEnv } from './utils/requireEnv';
 
-const providerUrl = FUEL_CHAIN.providerUrl;
-
+const { FUEL_PROVIDER } = requireEnv([
+  ['FUEL_PROVIDER', 'https://beta-5.fuel.network/graphql'],
+]);
 const { FUEL_EXPLORER_API_KEY } = process.env;
 
 // Create a server:
@@ -38,7 +39,7 @@ app.get(
   }),
 );
 
-const executor = createGraphqlFetch(providerUrl);
+const executor = createGraphqlFetch(FUEL_PROVIDER);
 const schema = createSchema(executor);
 
 app.post(
@@ -46,7 +47,7 @@ app.post(
   createHandler({
     schema,
     async context() {
-      return ContextDomain.createContext(providerUrl);
+      return ContextDomain.createContext(FUEL_PROVIDER);
     },
   }),
 );
@@ -56,8 +57,8 @@ app.get('/health', async (_, res) => {
   let providerUp = null;
   try {
     providerUp = (
-      await fetch(`${providerUrl.replace('/graphql', '/health')}`).then((res) =>
-        res.json(),
+      await fetch(`${FUEL_PROVIDER.replace('/graphql', '/health')}`).then(
+        (res) => res.json(),
       )
     ).up;
   } catch (_e) {

--- a/packages/graphql/tsup.config.mjs
+++ b/packages/graphql/tsup.config.mjs
@@ -32,7 +32,7 @@ export default defineConfig((options) => ({
         SERVER_PORT: port,
         CODE_GEN: true,
         WATCH: Boolean(options.watch),
-        NEXT_PUBLIC_FUEL_CHAIN_NAME: process.env.NEXT_PUBLIC_FUEL_CHAIN_NAME,
+        FUEL_PROVIDER: process.env.FUEL_PROVIDER,
       },
     });
     // Wait process to close until restarting

--- a/packages/graphql/tsup.config.mjs
+++ b/packages/graphql/tsup.config.mjs
@@ -16,7 +16,6 @@ export default defineConfig((options) => ({
   splitting: true,
   format: ['esm', 'cjs'],
   external: ['@fuels/assets'],
-  noExternal: ['app-commons'],
   sourcemap: true,
   clean: false,
   dts: !isServerBuild,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,9 +561,6 @@ importers:
       '@luckycatfactory/esbuild-graphql-loader':
         specifier: 3.8.1
         version: 3.8.1(esbuild@0.20.0)(graphql-tag@2.12.6)(graphql@16.8.1)
-      app-commons:
-        specifier: workspace:*
-        version: link:../app-commons
       chokidar:
         specifier: 3.5.3
         version: 3.5.3
@@ -4584,6 +4581,11 @@ packages:
     resolution: {integrity: sha512-R+oMDcqHCKGzFTX+bDRwBk8bIOS0OKTo3Vrl3Gj0gphHn0C7ovF6ylxnM8kW4+VzMD6e6N64e2e506+RD1+yQQ==}
     peerDependencies:
       jest: ^29.6.4
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
     dependencies:
       '@ariakit/test': 0.2.5(@testing-library/dom@9.3.4)(@testing-library/react@14.2.1)(react@18.2.0)
       '@chakra-ui/utils': 2.0.15
@@ -13248,6 +13250,9 @@ packages:
 
   /ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependenciesMeta:
+      ajv:
+        optional: true
     dependencies:
       ajv: 8.12.0
     dev: true


### PR DESCRIPTION
Revert change on graphql package related to provider URL, the graphql package uses a customizable providerUrl that doesn't match the pre-defined one. Also the graphql package is not a next.js package removing the need for pre fixed PUBLIC_NEXT env variables.