### PR TITLE
fix: remove block watcher to refresh balance

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   pull_request:
-    branches: [main, master]
+    branches: [main, master, release]
     types: [opened, synchronize, reopened]
 
 concurrency:
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   tests-e2e:
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -16,7 +16,7 @@ jobs:
   validate-title:
     name: Validate PR Title
     if: ${{ github.head_ref != 'changeset-release/master' }}
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: amannn/action-semantic-pull-request@v4
         env:
@@ -25,7 +25,7 @@ jobs:
   audit:
     name: Audit
     if: ${{ github.head_ref != 'changeset-release/master' }}
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       - uses: FuelLabs/github-actions/setups/node@master
@@ -39,7 +39,7 @@ jobs:
   lint-and-test:
     name: Lint
     if: ${{ github.head_ref != 'changeset-release/master' }}
-    runs-on: ubuntu-latest
+    runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - uses: actions/checkout@v3
       - uses: FuelLabs/github-actions/setups/node@master

--- a/packages/app-portal/src/systems/Chains/eth/hooks/useEthBalance.tsx
+++ b/packages/app-portal/src/systems/Chains/eth/hooks/useEthBalance.tsx
@@ -1,21 +1,14 @@
-import { useAccount, useBalance, useBlockNumber } from 'wagmi';
-
-import { useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
+import { useAccount, useBalance } from 'wagmi';
 
 export function useEthBalance(token?: `0x${string}`) {
-  const queryClient = useQueryClient();
-
   const { address } = useAccount();
-  const { data: blockNumber } = useBlockNumber({ watch: true });
-  const { data: ethBalance, queryKey: ethBalanceQueryKey } = useBalance({
+  const { data: ethBalance } = useBalance({
     address,
     token,
+    query: {
+      refetchInterval: 5000,
+    },
   });
-
-  useEffect(() => {
-    queryClient.invalidateQueries({ queryKey: ethBalanceQueryKey });
-  }, [queryClient, blockNumber, ethBalanceQueryKey]);
 
   return {
     ethBalance,

--- a/packages/e2e-tests/playwright.config.ts
+++ b/packages/e2e-tests/playwright.config.ts
@@ -9,7 +9,7 @@ const config: PlaywrightTestConfig = defineConfig({
   workers: 1,
   testMatch: join(__dirname, './bridge/**/*.test.ts'),
   testDir: join(__dirname, './bridge/'),
-  timeout: 60_000 * 10,
+  timeout: 60_000 * 7,
   expect: {
     timeout: 5000,
   },


### PR DESCRIPTION
The current implementation of the block watcher trigger multiples request at the same time increasing data usage

this PR address:
- make pr tests also run on `release` branch
- change machine of CI to `buildjet-4vcpu-ubuntu-2204`
- remove watcher of eth balance, now it will refresh every 5 seconds