### PR TITLE
fix: search error layout breaking on long inputs

### DIFF
--- a/packages/app-explorer/src/systems/Core/components/Search/SearchInput.tsx
+++ b/packages/app-explorer/src/systems/Core/components/Search/SearchInput.tsx
@@ -79,7 +79,11 @@ const SearchResultDropdown = forwardRef<HTMLDivElement, SearchDropdownProps>(
           {!searchResult && (
             <>
               <Dropdown.Item className="hover:bg-transparent focus:bg-transparent text-error hover:text-error focus:text-error">
-                {`"${searchValue}" is not a valid address.`}
+                {`"${shortAddress(
+                  searchValue,
+                  trimL,
+                  trimR,
+                )}" is not a valid address.`}
               </Dropdown.Item>
             </>
           )}


### PR DESCRIPTION

| Before | After |
---|---
| <img width="1093" alt="Screenshot 2024-04-26 at 14 54 03" src="https://github.com/FuelLabs/fuel-explorer/assets/114662397/76d43ef1-19c3-40a9-807c-5d6a6b22aa63"> | <img width="1093" alt="Screenshot 2024-04-26 at 14 54 03" src="https://github.com/FuelLabs/fuel-explorer/assets/3487334/8ecf494b-7081-4e99-9a08-a31818e69790"> |
