### PR TITLE
fix: sync output contract created with the new response

### DIFF
--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
@@ -117,7 +117,7 @@ const TxOutputContractCreated = createComponent<TxOutputProps, typeof Card>({
   id: 'TxOutputContractCreated',
   render: (_, { output, ...props }) => {
     const classes = styles();
-    const contractId = output.contract?.id as string;
+    const contractId = output.contractId as string;
 
     return (
       <Card {...props} className={cx('py-3', props.className)}>

--- a/packages/graphql/src/domains/Output.ts
+++ b/packages/graphql/src/domains/Output.ts
@@ -48,8 +48,8 @@ export class OutputDomain {
     const entries = Object.entries(groupBy(outputs, (i) => i.contract));
     return entries.map(([_, outputs]) => {
       const type = outputs[0].__typename;
-      const contract = outputs[0].contract;
-      return { contract, type, outputs };
+      const contractId = outputs[0].contract;
+      return { contractId, type, outputs };
     });
   }
 

--- a/packages/graphql/src/queries/tx-fragments.graphql
+++ b/packages/graphql/src/queries/tx-fragments.graphql
@@ -1,8 +1,3 @@
-fragment TransactionContractItem on Contract {
-  __typename
-  id
-}
-
 fragment TransactionStatus on TransactionStatus {
   __typename
   ... on SqueezedOutStatus {
@@ -186,9 +181,7 @@ fragment TransactionItem on Transaction {
     outputs {
       ...TransactionOutput
     }
-    contract {
-      id
-    }
+    contractId
     assetId
     inputIndex
     recipient

--- a/packages/graphql/src/services/extends.graphql
+++ b/packages/graphql/src/services/extends.graphql
@@ -64,7 +64,7 @@ type GroupedOutput {
   assetId: AssetId
   inputIndex: Int
   recipient: Address
-  contract: Contract
+  contractId: ContractId
 }
 
 enum TransactionAccountType {


### PR DESCRIPTION
Fixing the format of the `contractId` in the `ContractCreated` output. 
Previously, the `contractId` was an object (`contract.id`) in `beta-5`. 

With this update, it will be a regular string, consistent with the format used in the `testnet`.