### PR TITLE
fix: show correct operations for contract calls in block explorer

### DIFF
--- a/packages/graphql/src/queries/tx-fragments.graphql
+++ b/packages/graphql/src/queries/tx-fragments.graphql
@@ -91,7 +91,7 @@ fragment TransactionOutput on Output {
 
 fragment TransactionReceipt on Receipt {
   __typename
-  contractId
+  id
   to
   pc
   is


### PR DESCRIPTION
Closes #362 


before: https://app.fuel.network/tx/0xcc7335e031ea4728d6e8520ddec782140b7d5fd6fe94a080a6009bd1bf8b82c4/simple

after (fixed):  https://fuel-explorer-7hcl73n0d-fuel-labs.vercel.app/tx/0xcc7335e031ea4728d6e8520ddec782140b7d5fd6fe94a080a6009bd1bf8b82c4/simple