### PR TITLE
fix: Bridge - Too many requests going on transaction list

### DIFF
--- a/packages/app-portal/src/systems/Chains/fuel/services/txFuelToEth.ts
+++ b/packages/app-portal/src/systems/Chains/fuel/services/txFuelToEth.ts
@@ -48,6 +48,10 @@ export type TxFuelToEthInputs = {
     ethPublicClient: EthPublicClient;
     fuelProvider?: FuelProvider;
   };
+  calculateDelayBasedOnTransactionTimeToFinalize: {
+    txId?: string;
+    timeToFinalize?: string | null;
+  };
   waitBlockFinalization: {
     messageProof?: MessageProof;
     ethPublicClient: EthPublicClient;
@@ -258,6 +262,26 @@ export class TxFuelToEthService {
     return {
       estimatedFinishDate,
     };
+  }
+
+  static calculateDelayBasedOnTransactionTimeToFinalize(
+    input: TxFuelToEthInputs['calculateDelayBasedOnTransactionTimeToFinalize'],
+  ) {
+    const DEFAULT_DELAY_TIME_10_SECONDS = 10000;
+    if (!input.txId || !input.timeToFinalize) {
+      return DEFAULT_DELAY_TIME_10_SECONDS;
+    }
+    const CURRENT_TIMESTAMP = new Date().getTime();
+    const TIME_24_HOURS = 86400000;
+    const TIME_1_HOUR = 3600000;
+    const TIME_10_MINUTES = 600000;
+    const TIME_1_MINUTE = 60000;
+    const remainingTime = parseInt(input.timeToFinalize) - CURRENT_TIMESTAMP;
+    if (remainingTime > TIME_24_HOURS) return TIME_24_HOURS;
+    if (remainingTime > TIME_1_HOUR) return TIME_1_HOUR;
+    if (remainingTime > TIME_10_MINUTES) return TIME_10_MINUTES;
+    if (remainingTime > TIME_1_MINUTE) return TIME_1_MINUTE;
+    return DEFAULT_DELAY_TIME_10_SECONDS;
   }
 
   static async getMessageProof(input: TxFuelToEthInputs['getMessageProof']) {

--- a/packages/app-portal/src/systems/Chains/fuel/utils/txCache.ts
+++ b/packages/app-portal/src/systems/Chains/fuel/utils/txCache.ts
@@ -1,5 +1,6 @@
 const HASH_DONE_KEY_SUBSTRING = 'fuelToEthTx';
 const TX_CREATED_KEY_SUBSTRING = 'fuelTxCreated';
+const TX_TIME_TO_FINALIZE = 'fuelTxTimeToFinalize';
 
 export const FuelTxCache = {
   getTxIsDone: (blockHash: string) => {
@@ -11,9 +12,21 @@ export const FuelTxCache = {
   setTxIsDone: (blockHash: string) => {
     return localStorage.setItem(generateHashDoneKey(blockHash), 'true');
   },
+  setTxTimeToFinalize: (txId: string, timestamp: number) => {
+    return localStorage.setItem(
+      `${TX_TIME_TO_FINALIZE}${txId}`,
+      `${timestamp}`,
+    );
+  },
+  getTxTimeToFinalize: (txId: string) => {
+    return localStorage.getItem(`${TX_TIME_TO_FINALIZE}${txId}`);
+  },
   clean: () => {
     Object.keys(localStorage).forEach((key) => {
-      if (key.includes(HASH_DONE_KEY_SUBSTRING)) {
+      if (
+        key.includes(HASH_DONE_KEY_SUBSTRING) ||
+        key.includes(TX_TIME_TO_FINALIZE)
+      ) {
         localStorage.removeItem(key);
       }
     });

--- a/packages/tests/calculateDelayBasedOnTransactionTimeToFinalize.test.ts
+++ b/packages/tests/calculateDelayBasedOnTransactionTimeToFinalize.test.ts
@@ -1,0 +1,78 @@
+import { TxFuelToEthService } from '../app-portal/src/systems/Chains/fuel/services/txFuelToEth';
+const calculateDelayBasedOnTransactionTimeToFinalize =
+  TxFuelToEthService.calculateDelayBasedOnTransactionTimeToFinalize;
+
+describe('calculateDelayBasedOnTransactionTimeToFinalize', () => {
+  test('Should calculate delay based on more than two days to finalize', () => {
+    console.log(process.env.NEXT_PUBLIC_FUEL_CHAIN_NAME);
+    const actualDate = new Date('2024-06-20T15:00:01');
+    const futureDate = new Date('2024-06-22T15:00:11');
+    jest.useFakeTimers().setSystemTime(actualDate);
+    const delay = calculateDelayBasedOnTransactionTimeToFinalize({
+      txId: 'abc',
+      timeToFinalize: `${futureDate.getTime()}`,
+    });
+    expect(delay).toBe(86400000);
+    jest.restoreAllMocks();
+  });
+
+  it('Should calculate delay based on more than one day to finalize', () => {
+    const actualDate = new Date('2024-06-20T15:00:01');
+    const futureDate = new Date('2024-06-21T15:00:11');
+    jest.useFakeTimers().setSystemTime(actualDate);
+    const delay = calculateDelayBasedOnTransactionTimeToFinalize({
+      txId: 'abc',
+      timeToFinalize: `${futureDate.getTime()}`,
+    });
+    expect(delay).toBe(86400000);
+    jest.restoreAllMocks();
+  });
+
+  it('Should calculate delay based on more than one hour to finalize', () => {
+    const actualDate = new Date('2024-06-20T15:00:01');
+    const futureDate = new Date('2024-06-20T16:00:11');
+    jest.useFakeTimers().setSystemTime(actualDate);
+    const delay = calculateDelayBasedOnTransactionTimeToFinalize({
+      txId: 'abc',
+      timeToFinalize: `${futureDate.getTime()}`,
+    });
+    expect(delay).toBe(3600000);
+    jest.restoreAllMocks();
+  });
+
+  it('Should calculate delay based on more than ten minutes to finalize', () => {
+    const actualDate = new Date('2024-06-20T15:00:01');
+    const futureDate = new Date('2024-06-20T15:10:11');
+    jest.useFakeTimers().setSystemTime(actualDate);
+    const delay = calculateDelayBasedOnTransactionTimeToFinalize({
+      txId: 'abc',
+      timeToFinalize: `${futureDate.getTime()}`,
+    });
+    expect(delay).toBe(600000);
+    jest.restoreAllMocks();
+  });
+
+  it('Should calculate delay based on more than one minute to finalize', () => {
+    const actualDate = new Date('2024-06-20T15:00:01');
+    const futureDate = new Date('2024-06-20T15:01:11');
+    jest.useFakeTimers().setSystemTime(actualDate);
+    const delay = calculateDelayBasedOnTransactionTimeToFinalize({
+      txId: 'abc',
+      timeToFinalize: `${futureDate.getTime()}`,
+    });
+    expect(delay).toBe(60000);
+    jest.restoreAllMocks();
+  });
+
+  it('Should calculate delay based on less than one minue to finalize', () => {
+    const actualDate = new Date('2024-06-20T15:00:01');
+    const futureDate = new Date('2024-06-20T15:00:11');
+    jest.useFakeTimers().setSystemTime(actualDate);
+    const delay = calculateDelayBasedOnTransactionTimeToFinalize({
+      txId: 'abc',
+      timeToFinalize: `${futureDate.getTime()}`,
+    });
+    expect(delay).toBe(10000);
+    jest.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
- Closes #378 

Changed the 10 seconds pooling to a function that calculates the most optimized time to retry on events waitBlockCommit and waitBlockFinalization based on time to finalize