### PR TITLE
chore: change current FUEL connectors

### DIFF
--- a/packages/app-portal/src/systems/Settings/providers/FuelConnectProvider.tsx
+++ b/packages/app-portal/src/systems/Settings/providers/FuelConnectProvider.tsx
@@ -1,8 +1,8 @@
 import {
+  BakoSafeConnector,
   FuelWalletConnector,
   FuelWalletDevelopmentConnector,
   FueletWalletConnector,
-  WalletConnectConnector,
 } from '@fuels/connectors';
 import { FuelProvider } from '@fuels/react';
 import { useTheme } from 'next-themes';
@@ -22,7 +22,7 @@ export function FuelConnectProvider({ children }: ProvidersProps) {
         connectors: [
           new FuelWalletConnector(),
           new FueletWalletConnector(),
-          new WalletConnectConnector(),
+          new BakoSafeConnector(),
           new FuelWalletDevelopmentConnector(),
         ],
       }}


### PR DESCRIPTION
- Remove `WalletConnect (Ethereum Wallets)` connector, as it currently has conflicts with wagmi instance from ETH side, making the experience sort of bugged. Follow up issue to come right next -> https://github.com/FuelLabs/fuel-explorer/issues/414
- Added `BakoSafe` connnector