### PR TITLE
feat: add featured projects

### DIFF
--- a/packages/app-portal/src/systems/Ecosystem/components/EcosystemHeader/EcosystemHeader.tsx
+++ b/packages/app-portal/src/systems/Ecosystem/components/EcosystemHeader/EcosystemHeader.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Input, Separator } from '@fuels/ui';
+import { Button, Flex, Input, Separator, Switch, Text } from '@fuels/ui';
 import { IconSearch } from '@tabler/icons-react';
 import { PageTitle } from 'app-commons';
 import { tv } from 'tailwind-variants';
@@ -7,10 +7,14 @@ export function EcosystemHeader({
   disabled,
   search,
   onSearchChange,
+  onBuildingHiddenChange,
+  isBuildingHidden,
 }: {
   disabled?: boolean;
   search?: string;
+  isBuildingHidden?: boolean;
   onSearchChange?: (value: string) => void;
+  onBuildingHiddenChange?: (value: boolean) => void;
 }) {
   const classes = styles();
 
@@ -39,7 +43,16 @@ export function EcosystemHeader({
             <IconSearch size={16} />
           </Input.Slot>
         </Input>
-        <Flex justify="end">
+        <Flex justify="between" flexBasis={'100%'}>
+          <label className={classes.switchLiveOnlyWrapper()}>
+            <Switch
+              defaultChecked={!isBuildingHidden}
+              mr="2"
+              onCheckedChange={onBuildingHiddenChange}
+            />
+            {/* Show "Live" only */}
+            <Text color="gray">Show "Live" only</Text>
+          </label>
           <Button
             as="a"
             href="https://airtable.com/appEO4t5bVydYgzCk/pagiUOEi5aqbtQK0T/form"
@@ -60,5 +73,7 @@ const styles = tv({
   slots: {
     searchBar: 'flex-col sm:justify-between sm:flex-row',
     searchBarInput: 'w-full sm:w-[350px] h-[44px]',
+    switchLiveOnlyWrapper:
+      'flex flex-row items-center justify-between mr-2 ml-1',
   },
 });

--- a/packages/app-portal/src/systems/Ecosystem/components/ProjectItem/ProjectItem.tsx
+++ b/packages/app-portal/src/systems/Ecosystem/components/ProjectItem/ProjectItem.tsx
@@ -43,8 +43,9 @@ export const ProjectItem: ProjectItemComponent = ({
   status,
   github,
   isLive,
+  isFeatured,
 }: ProjectItemProps) => {
-  const classes = styles();
+  const classes = styles({ isFeatured });
 
   const onCardPress = () => {
     window.open(url, '_blank');
@@ -57,6 +58,7 @@ export const ProjectItem: ProjectItemComponent = ({
       })}
       className={classes.card()}
       onClick={onCardPress}
+      variant={isFeatured || isLive ? 'classic' : 'ghost'}
     >
       <Card.Body className={classes.body()}>
         <ProjecImage name={name} image={image} />
@@ -137,7 +139,7 @@ export const ProjectItem: ProjectItemComponent = ({
           </HStack>
         </VStack>
       </Card.Body>
-      <Card.Footer>
+      <Card.Footer className={classes.footer()}>
         {status?.map((s, index) => (
           <Badge
             key={index}
@@ -149,6 +151,16 @@ export const ProjectItem: ProjectItemComponent = ({
             {s}
           </Badge>
         ))}
+        {isFeatured ? (
+          <Badge
+            color="yellow"
+            size="1"
+            className={classes.tag()}
+            variant="surface"
+          >
+            Featured
+          </Badge>
+        ) : null}
         {isLive ? (
           <Badge
             color="green"
@@ -178,7 +190,8 @@ const styles = tv({
     card: [
       'cursor-pointer gap-2',
       'transition-all duration-200 ease-in-out',
-      'hover:border-1 hover:border-brand hover:scale-105',
+      'border-none border-brand',
+      'hover:border hover:border-solid hover:scale-105',
     ],
     details: 'flex flex-col justify-between flex-1',
     link: 'underline p-0 pointer-events-none text-sm',
@@ -194,6 +207,14 @@ const styles = tv({
     textProjectName: 'text-heading',
     textDescription: 'text-sm',
     socialButton: 'bg-transparent',
+    footer: 'items-end',
+  },
+  variants: {
+    isFeatured: {
+      true: {
+        card: 'border border-solid border-yellow-7 hover:border-yellow-8 hover:border-2',
+      },
+    },
   },
 });
 

--- a/packages/app-portal/src/systems/Ecosystem/data/projects.json
+++ b/packages/app-portal/src/systems/Ecosystem/data/projects.json
@@ -166,6 +166,7 @@
   },
   {
     "isLive": false,
+    "isFeatured": true,
     "name": "Fluid Protocol",
     "url": "https://fluidprotocol.xyz/",
     "tags": ["DeFi"],
@@ -243,6 +244,7 @@
   },
   {
     "isLive": false,
+    "isFeatured": true,
     "name": "Griffy",
     "url": "https://griffy.app/",
     "tags": ["Prediction Market"],
@@ -309,6 +311,7 @@
   },
   {
     "isLive": true,
+    "isFeatured": true,
     "name": "Mira Exchange",
     "url": "https://mira.ly/",
     "tags": ["DeFi"],
@@ -441,6 +444,7 @@
   },
   {
     "isLive": true,
+    "isFeatured": true,
     "name": "Spark",
     "url": "https://sprk.fi/",
     "tags": ["DeFi"],
@@ -485,6 +489,7 @@
   },
   {
     "isLive": true,
+    "isFeatured": true,
     "name": "Swaylend",
     "url": "https://swaylend.com/",
     "tags": ["DeFi"],
@@ -507,6 +512,7 @@
   },
   {
     "isLive": false,
+    "isFeatured": true,
     "name": "Thunder",
     "url": "https://beta.thundernft.market/",
     "tags": ["Marketplace", "NFT"],

--- a/packages/app-portal/src/systems/Ecosystem/machines/ecosystemMachine.tsx
+++ b/packages/app-portal/src/systems/Ecosystem/machines/ecosystemMachine.tsx
@@ -22,6 +22,7 @@ type MachineContext = {
   search: string;
   tags: string[];
   filter: string;
+  isBuildingHidden: boolean;
 };
 
 type MachineServices = {
@@ -55,6 +56,10 @@ type EcosystemMachineEvents =
   | {
       type: 'CLEAR_FILTER';
       input: null;
+    }
+  | {
+      type: 'TOGGLE_IS_BUILDING_HIDDEN';
+      input: null;
     };
 
 const initialState: MachineContext = {
@@ -63,6 +68,7 @@ const initialState: MachineContext = {
   search: '',
   tags: [],
   filter: '',
+  isBuildingHidden: true,
 };
 
 export function sortAtoZ(a: string, b: string) {
@@ -102,6 +108,9 @@ export const ecosystemMachine = createMachine(
           },
           CLEAR_FILTER: {
             actions: ['clearFilter'],
+          },
+          TOGGLE_IS_BUILDING_HIDDEN: {
+            actions: ['toggleIsBuildingHidden'],
           },
         },
       },
@@ -164,6 +173,10 @@ export const ecosystemMachine = createMachine(
         ...ctx,
         search: '',
         filter: '',
+      })),
+      toggleIsBuildingHidden: assign((ctx) => ({
+        ...ctx,
+        isBuildingHidden: !ctx.isBuildingHidden,
       })),
     },
   },

--- a/packages/app-portal/src/systems/Ecosystem/pages/Ecosystem.tsx
+++ b/packages/app-portal/src/systems/Ecosystem/pages/Ecosystem.tsx
@@ -7,8 +7,15 @@ import { useEcosystem } from '../hooks/useEcosystem';
 
 export function Ecosystem() {
   const classes = styles();
-  const { tags, isLoading, filter, search, handlers, filteredProjects } =
-    useEcosystem();
+  const {
+    tags,
+    isLoading,
+    filter,
+    search,
+    handlers,
+    filteredProjects,
+    isBuildingHidden,
+  } = useEcosystem();
 
   const handleSearch = (query: string) => {
     handlers.searchProjects({ query });
@@ -24,7 +31,12 @@ export function Ecosystem() {
 
   return (
     <VStack gap="6" flexGrow="1" className={classes.content()}>
-      <EcosystemHeader search={search} onSearchChange={handleSearch} />
+      <EcosystemHeader
+        search={search}
+        onSearchChange={handleSearch}
+        onBuildingHiddenChange={handlers.toggleIsBuildingHidden}
+        isBuildingHidden={isBuildingHidden}
+      />
       <EcosystemTags
         tags={tags}
         activeTag={filter}

--- a/packages/app-portal/src/systems/Ecosystem/types.ts
+++ b/packages/app-portal/src/systems/Ecosystem/types.ts
@@ -9,4 +9,5 @@ export type Project = {
   discord?: string;
   status?: string[];
   isLive?: boolean;
+  isFeatured?: boolean;
 };


### PR DESCRIPTION
- Closes #471 
- Closes #527 
- Closes #528 

Added "Featured" option to projects
- Featured will show highlighted with a yellow border + yellow "Featured" tag
- Featured will be ordered first
- Added toggle to select if will show only "Live" projects or if it will show "Building" also
- Make "Building Projects" a bit less highlighted


These are the initial projects setup as "Featured"
```
Mira (DEX)
Swaylend (Lending)
Spark (Order Book)
Griffy (Prediction Market)
Thunder (NFT Marketplace)
Fluid (Stablecoin)
```