### PR TITLE
refactor: transaction screen

### DIFF
--- a/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
+++ b/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
@@ -13,6 +13,7 @@ import {
 import Image from 'next/image';
 import { TxIcon } from '~/systems/Transaction/component/TxIcon/TxIcon';
 
+import type { TxIconType } from '~/systems/Transaction/types';
 import { useAsset } from '../../hooks/useAsset';
 
 const ICON_SIZE = 38;
@@ -21,6 +22,7 @@ type AssetItemProps = HStackProps & {
   assetId: string;
   prefix?: string;
   isLoading?: boolean;
+  txIconTypeFallback?: TxIconType;
 };
 
 export function AssetItem({
@@ -28,6 +30,7 @@ export function AssetItem({
   assetId,
   children,
   isLoading,
+  txIconTypeFallback,
   ...props
 }: AssetItemProps) {
   const asset = useAsset(assetId);
@@ -47,7 +50,7 @@ export function AssetItem({
               />
             </Flex>
           ) : (
-            <TxIcon type="Mint" status="Submitted" />
+            <TxIcon type={txIconTypeFallback || 'Mint'} status="Submitted" />
           )
         }
       />

--- a/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
+++ b/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
@@ -23,7 +23,6 @@ type AssetItemProps = HStackProps & {
   assetId: string;
   prefix?: string;
   isLoading?: boolean;
-  reversed?: boolean;
   txIconTypeFallback?: TxIconType;
 };
 
@@ -33,7 +32,6 @@ export function AssetItem({
   children,
   isLoading,
   txIconTypeFallback,
-  reversed,
   ...props
 }: AssetItemProps) {
   const asset = useAsset(assetId);
@@ -58,16 +56,13 @@ export function AssetItem({
           )
         }
       />
-      <Box
-        data-reversed={reversed || !asset?.symbol}
-        className="flex flex-col [&[data-reversed=true]]:flex-col-reverse"
-      >
+      <Box className="flex flex-col">
         <LoadingWrapper
           isLoading={isLoading}
           loadingEl={<LoadingBox className="w-40 h-6" />}
           regularEl={
             <HStack gap="2">
-              {prefix && <Text className="font-medium">{prefix} s</Text>}
+              {prefix && <Text className="font-medium">{prefix}</Text>}
               {asset?.symbol ? (
                 <Tooltip content={assetId}>
                   <Copyable value={assetId}>

--- a/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
+++ b/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
@@ -22,6 +22,7 @@ type AssetItemProps = HStackProps & {
   assetId: string;
   prefix?: string;
   isLoading?: boolean;
+  reversed?: boolean;
   txIconTypeFallback?: TxIconType;
 };
 
@@ -31,6 +32,7 @@ export function AssetItem({
   children,
   isLoading,
   txIconTypeFallback,
+  reversed,
   ...props
 }: AssetItemProps) {
   const asset = useAsset(assetId);
@@ -55,7 +57,7 @@ export function AssetItem({
         }
       />
       <Box
-        data-reversed={!asset?.symbol}
+        data-reversed={reversed || !asset?.symbol}
         className="flex flex-col [&[data-reversed=true]]:flex-col-reverse"
       >
         <LoadingWrapper

--- a/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
+++ b/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
@@ -1,5 +1,6 @@
 import type { HStackProps } from '@fuels/ui';
 import {
+  Address,
   Box,
   Copyable,
   Flex,
@@ -8,7 +9,7 @@ import {
   LoadingWrapper,
   Text,
   Tooltip,
-  shortAddress,
+  useBreakpoints,
 } from '@fuels/ui';
 import Image from 'next/image';
 import { TxIcon } from '~/systems/Transaction/component/TxIcon/TxIcon';
@@ -36,6 +37,7 @@ export function AssetItem({
   ...props
 }: AssetItemProps) {
   const asset = useAsset(assetId);
+  const { isMobile } = useBreakpoints();
   return (
     <HStack {...props} align="center">
       <LoadingWrapper
@@ -77,9 +79,14 @@ export function AssetItem({
                 </Tooltip>
               ) : (
                 <Tooltip content={assetId}>
-                  <Copyable value={assetId} className="text-gray-11 font-mono">
-                    {shortAddress(assetId)}
-                  </Copyable>
+                  <Address
+                    value={assetId}
+                    prefix="Asset:"
+                    className="text-gray-11 font-mono"
+                    addressOpts={
+                      isMobile ? { trimLeft: 4, trimRight: 2 } : undefined
+                    }
+                  />
                 </Tooltip>
               )}
             </HStack>

--- a/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
+++ b/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
@@ -54,13 +54,16 @@ export function AssetItem({
           )
         }
       />
-      <Box>
+      <Box
+        data-reversed={!asset?.symbol}
+        className="flex flex-col [&[data-reversed=true]]:flex-col-reverse"
+      >
         <LoadingWrapper
           isLoading={isLoading}
           loadingEl={<LoadingBox className="w-40 h-6" />}
           regularEl={
             <HStack gap="2">
-              {prefix && <Text className="font-medium">{prefix}</Text>}
+              {prefix && <Text className="font-medium">{prefix} s</Text>}
               {asset?.symbol ? (
                 <Tooltip content={assetId}>
                   <Copyable value={assetId}>

--- a/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
+++ b/packages/app-explorer/src/systems/Asset/components/AssetItem/AssetItem.tsx
@@ -61,8 +61,12 @@ export function AssetItem({
           isLoading={isLoading}
           loadingEl={<LoadingBox className="w-40 h-6" />}
           regularEl={
-            <HStack gap="2">
-              {prefix && <Text className="font-medium">{prefix}</Text>}
+            <HStack gap="1" className="items-center">
+              {prefix && (
+                <Text className="font-normal text-sm text-secondary font-mono">
+                  {prefix}
+                </Text>
+              )}
               {asset?.symbol ? (
                 <Tooltip content={assetId}>
                   <Copyable value={assetId}>
@@ -76,7 +80,6 @@ export function AssetItem({
                 <Tooltip content={assetId}>
                   <Address
                     value={assetId}
-                    prefix="Asset:"
                     className="text-gray-11 font-mono"
                     addressOpts={
                       isMobile ? { trimLeft: 4, trimRight: 2 } : undefined

--- a/packages/app-explorer/src/systems/Core/components/Amount/Amount.tsx
+++ b/packages/app-explorer/src/systems/Core/components/Amount/Amount.tsx
@@ -10,13 +10,21 @@ import { useFuelAsset } from '~/systems/Asset/hooks/useFuelAsset';
 import { cx } from '../../utils/cx';
 import { formatZeroUnits } from '../../utils/format';
 
-type AmountProps = BaseProps<{
-  value?: BN | null;
-  assetId?: string | null;
-  hideIcon?: boolean;
-  hideSymbol?: boolean;
-  iconSize?: number;
-}>;
+type AmountProps =
+  | BaseProps<{
+      value?: BN | null;
+      assetId?: string | null;
+      hideIcon?: boolean;
+      hideSymbol?: boolean;
+      iconSize?: number;
+    }>
+  | BaseProps<{
+      value?: BN | null;
+      assetId?: never | null;
+      hideIcon?: never | true;
+      hideSymbol?: never | true;
+      iconSize?: never;
+    }>;
 
 export function Amount({
   value,

--- a/packages/app-explorer/src/systems/Transaction/component/TxIcon/TxIcon.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxIcon/TxIcon.tsx
@@ -46,7 +46,7 @@ export const TX_STATUS_MAP: Record<TxStatus, string> = {
 
 type TxIconProps = VariantProps<typeof styles> &
   BaseProps<{
-    type: string;
+    type: TxIconType;
     status?: TxStatus;
     color?: BadgeProps['color'];
     label?: string;

--- a/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputCoin/TxInputCoin.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputCoin/TxInputCoin.tsx
@@ -42,7 +42,7 @@ export const TxInputCoin = createComponent<
             </Badge>
 
             <Flex className="w-full items-start tablet:items-center flex flex-col tablet:flex-row gap-2 tablet:gap-4">
-              <AssetItem assetId={assetId} className="flex-1">
+              <AssetItem assetId={assetId} className="flex-1" reversed>
                 <Address
                   prefix="From:"
                   value={input.owner || ''}

--- a/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputCoin/TxInputCoin.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputCoin/TxInputCoin.tsx
@@ -42,7 +42,11 @@ export const TxInputCoin = createComponent<
             </Badge>
 
             <Flex className="w-full items-start tablet:items-center flex flex-col tablet:flex-row gap-2 tablet:gap-4">
-              <AssetItem assetId={assetId} className="flex-1" prefix="Asset:">
+              <AssetItem
+                assetId={assetId}
+                className="flex-1 text-sm"
+                prefix="Asset:"
+              >
                 <Address
                   prefix="From:"
                   value={input.owner || ''}

--- a/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputCoin/TxInputCoin.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputCoin/TxInputCoin.tsx
@@ -42,7 +42,7 @@ export const TxInputCoin = createComponent<
             </Badge>
 
             <Flex className="w-full items-start tablet:items-center flex flex-col tablet:flex-row gap-2 tablet:gap-4">
-              <AssetItem assetId={assetId} className="flex-1" reversed>
+              <AssetItem assetId={assetId} className="flex-1" prefix="Asset:">
                 <Address
                   prefix="From:"
                   value={input.owner || ''}

--- a/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputCoin/TxInputCoin.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputCoin/TxInputCoin.tsx
@@ -35,7 +35,7 @@ export const TxInputCoin = createComponent<
           <Flex className="flex flex-col items-center tablet:flex-row gap-2 w-full">
             <Badge
               color="gray"
-              className="font-mono justify-start tablet:justify-center hidden tablet:flex tablet:min-w-[70px] tablet:w-[70px] tablet:max-w-[70px] items-center"
+              className="font-mono ml-14 tablet:ml-0 self-start tablet:self-center justify-center flex min-w-[70px] w-[70px] max-w-[70px] items-center"
               size="1"
             >
               COIN
@@ -58,13 +58,6 @@ export const TxInputCoin = createComponent<
               </AssetItem>
               {amount && (
                 <Box className="w-full tablet:w-auto tablet:ml-0 justify-between flex flex-row tablet:block pl-14">
-                  <Badge
-                    color="gray"
-                    className="font-mono tablet:hidden min-w-[70px] w-[70px] max-w-[70px] items-center justify-center"
-                    size="1"
-                  >
-                    COIN
-                  </Badge>
                   <Amount
                     hideIcon
                     hideSymbol

--- a/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputContract/TxInputContract.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputContract/TxInputContract.tsx
@@ -31,7 +31,7 @@ export const TxInputContract = createComponent<
     return (
       <Collapsible {...props}>
         <Collapsible.Header>
-          <Flex className="flex flex-col-reverse items-start  tablet:items-center tablet:flex-row gap-2 w-full">
+          <Flex className="flex flex-col items-start  tablet:items-center tablet:flex-row gap-2 w-full">
             <Badge
               color="gray"
               className="font-mono justify-center ml-14 tablet:ml-0 tablet:flex min-w-[70px] w-[70px] max-w-[70px] items-center"

--- a/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputContract/TxInputContract.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputContract/TxInputContract.tsx
@@ -42,9 +42,6 @@ export const TxInputContract = createComponent<
             <HStack className="items-center justify-center gap-4">
               <TxIcon type="ContractCall" status="Submitted" />
               <VStack className="flex-1" gap="0">
-                <Text className="flex items-center gap-2 text-md">
-                  Contract
-                </Text>
                 <Address
                   prefix="Address:"
                   value={contractId}
@@ -55,6 +52,18 @@ export const TxInputContract = createComponent<
                   linkProps={{
                     as: NextLink,
                     href: Routes.contractAssets(contractId),
+                  }}
+                />
+                <Address
+                  prefix="Utxo Id:"
+                  value={utxoId}
+                  className="text-white"
+                  addressOpts={
+                    isMobile ? { trimLeft: 4, trimRight: 2 } : undefined
+                  }
+                  linkProps={{
+                    as: NextLink,
+                    href: Routes.txSimple(utxoId?.slice(0, -4)),
                   }}
                 />
               </VStack>

--- a/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputMessage/TxInputMessage.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxInput/TxInputMessage/TxInputMessage.tsx
@@ -1,16 +1,18 @@
 import {
   Address,
   Badge,
+  Box,
   Collapsible,
   Flex,
   HStack,
-  Text,
   VStack,
   createComponent,
 } from '@fuels/ui';
 import NextLink from 'next/link';
 
+import { bn } from 'fuels';
 import { Routes } from '~/routes';
+import { Amount } from '~/systems/Core/components/Amount/Amount';
 import { TxIcon } from '~/systems/Transaction/component/TxIcon/TxIcon';
 import type { TxInputMessageProps } from './types';
 
@@ -22,6 +24,7 @@ export const TxInputMessage = createComponent<
   render: (_, { input, ...props }) => {
     const { sender, recipient, data } = input;
 
+    const amount = input.amount;
     if (!sender || !recipient) return null;
 
     return (
@@ -30,18 +33,17 @@ export const TxInputMessage = createComponent<
           <Flex className="flex flex-col items-center tablet:flex-row gap-2 w-full">
             <Badge
               color="gray"
-              className="font-mono justify-start tablet:justify-center hidden tablet:flex tablet:min-w-[70px] tablet:w-[70px] tablet:max-w-[70px] items-center"
+              className="font-mono ml-14 tablet:ml-0 self-start tablet:self-center justify-center flex min-w-[70px] w-[70px] max-w-[70px] items-center"
               size="1"
             >
               MESSAGE
             </Badge>
 
             <Flex className="w-full items-start tablet:items-end flex flex-col tablet:flex-row">
-              <HStack className="gap-4 tablet:items-center tablet:flex-1">
+              <HStack className="gap-4 tablet:items-center tablet:flex-1 ">
                 <TxIcon type="Message" status="Submitted" />
-                <Text className="hidden tablet:block">Message</Text>
-                <VStack className="gap-2 tablet:flex-1">
-                  <VStack className="gap-1 tablet:flex-1 tablet:items-end">
+                <Flex className="gap-1 flex-col tablet:flex-row items-center flex-1">
+                  <VStack className="gap-1 items-start flex-1">
                     <Address
                       value={sender}
                       prefix="Sender:"
@@ -59,14 +61,12 @@ export const TxInputMessage = createComponent<
                       }}
                     />
                   </VStack>
-                  <Badge
-                    color="gray"
-                    className="font-mono tablet:hidden min-w-[70px] w-[70px] max-w-[70px] items-center justify-center"
-                    size="1"
-                  >
-                    MESSAGE
-                  </Badge>
-                </VStack>
+                  {!!amount && (
+                    <Box className="w-full tablet:w-auto tablet:ml-0 justify-start flex flex-row tablet:block">
+                      <Amount hideIcon hideSymbol value={bn(amount)} />
+                    </Box>
+                  )}
+                </Flex>
               </HStack>
             </Flex>
           </Flex>

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
@@ -55,7 +55,7 @@ const TxOutputCoin = createComponent<
           </AssetItem>
           <HStack className="hidden tablet:flex items-center gap-2">
             <Icon icon={IconArrowUp} className="text-success" />
-            {amount && (
+            {!!amount && (
               <Amount
                 hideSymbol
                 hideIcon

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
@@ -3,6 +3,7 @@ import type {
   GQLCoinOutput,
   GQLContractCreated,
   GQLTransactionOutputFragment,
+  GQLVariableOutput,
 } from '@fuel-explorer/graphql';
 import {
   Address,
@@ -30,7 +31,7 @@ type TxOutputProps<T = GQLTransactionOutputFragment> = CardProps & {
 };
 
 const TxOutputCoin = createComponent<
-  TxOutputProps<GQLChangeOutput | GQLCoinOutput>,
+  TxOutputProps<GQLChangeOutput | GQLCoinOutput | GQLVariableOutput>,
   typeof Card
 >({
   id: 'TxOutputCoin',
@@ -104,6 +105,7 @@ const TxOutputContractCreated = createComponent<
 
 export function TxOutput({ output, ...props }: TxOutputProps) {
   if (
+    isOutput<GQLVariableOutput>(output, 'VariableOutput') ||
     isOutput<GQLChangeOutput>(output, 'ChangeOutput') ||
     isOutput<GQLCoinOutput>(output, 'CoinOutput')
   ) {

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
@@ -2,155 +2,15 @@ import type {
   GQLChangeOutput,
   GQLCoinOutput,
   GQLContractCreated,
-  GQLTransactionOutputFragment,
   GQLVariableOutput,
 } from '@fuel-explorer/graphql';
-import {
-  Address,
-  Badge,
-  Card,
-  Flex,
-  HStack,
-  Icon,
-  Text,
-  VStack,
-  createComponent,
-  cx,
-} from '@fuels/ui';
-import type { CardProps } from '@fuels/ui';
-import { IconArrowUp } from '@tabler/icons-react';
-import { bn } from 'fuels';
-import NextLink from 'next/link';
-import { tv } from 'tailwind-variants';
-import { Routes } from '~/routes';
-import { AssetItem } from '~/systems/Asset/components/AssetItem/AssetItem';
-import { Amount } from '~/systems/Core/components/Amount/Amount';
-import { TxIconType } from '~/systems/Transaction/types';
-import { TxIcon } from '../TxIcon/TxIcon';
+import { memo } from 'react';
 import { isOutput } from './TxOutput.utils';
+import { TxOutputCoin } from './TxOutputCoin';
+import { TxOutputContractCreated } from './TxOutputContractCreated';
+import type { TxOutputProps } from './types';
 
-const typeNameMap: Record<GQLTransactionOutputFragment['__typename'], string> =
-  {
-    ContractOutput: 'OUTPUT',
-    ContractCreated: 'CREATED',
-    VariableOutput: 'VARIABLE',
-    ChangeOutput: 'CHANGE',
-    CoinOutput: 'COIN',
-  };
-
-const txIconTypeMap: Record<
-  GQLTransactionOutputFragment['__typename'],
-  TxIconType
-> = {
-  ContractOutput: 'Contract',
-  ContractCreated: 'Contract Created',
-  VariableOutput: 'Mint',
-  ChangeOutput: 'Wallet',
-  CoinOutput: 'Wallet',
-};
-
-type TxOutputProps<T = GQLTransactionOutputFragment> = CardProps & {
-  output: T;
-};
-
-const TxOutputCoin = createComponent<
-  TxOutputProps<GQLChangeOutput | GQLCoinOutput | GQLVariableOutput>,
-  typeof Card
->({
-  id: 'TxOutputCoin',
-  render: (_, { output, ...props }) => {
-    const classes = styles();
-    if (!output.assetId) return null;
-    const assetId = output.assetId;
-    const amount = output.amount;
-    const badgeLabel = typeNameMap?.[output?.__typename] ?? 'UNKNOWN';
-    const txIconTypeFallback = txIconTypeMap?.[output?.__typename] ?? 'Mint';
-
-    return (
-      <Card {...props} className={cx('py-3', props.className)}>
-        <Card.Header className={classes.header()}>
-          <Badge
-            color="gray"
-            className="font-mono justify-center ml-14 tablet:ml-0 tablet:flex min-w-[70px] w-[70px] max-w-[70px] items-center"
-            size="1"
-          >
-            {badgeLabel}
-          </Badge>
-          <Flex className={classes.content()}>
-            <AssetItem
-              assetId={assetId}
-              txIconTypeFallback={txIconTypeFallback}
-            >
-              <Address
-                prefix="To:"
-                value={output.to || ''}
-                linkProps={{
-                  as: NextLink,
-                  href: Routes.accountAssets(output.to!),
-                }}
-              />
-            </AssetItem>
-          </Flex>
-          <HStack className={classes.amount()}>
-            <Icon icon={IconArrowUp} className="text-success" />
-            {!!amount && (
-              <Amount
-                hideSymbol
-                hideIcon
-                assetId={assetId}
-                value={bn(amount)}
-              />
-            )}
-          </HStack>
-        </Card.Header>
-      </Card>
-    );
-  },
-});
-
-const TxOutputContractCreated = createComponent<
-  TxOutputProps<GQLContractCreated>,
-  typeof Card
->({
-  id: 'TxOutputContractCreated',
-  render: (_, { output, ...props }) => {
-    const classes = styles();
-    const contractId = output.contract;
-    const badgeLabel = typeNameMap?.[output?.__typename] ?? 'UNKNOWN';
-
-    return (
-      <Card {...props} className={cx('py-3', props.className)}>
-        <Card.Header className={classes.header()}>
-          <Flex className={classes.content()}>
-            <Badge
-              color="gray"
-              className="font-mono justify-center ml-14 tablet:ml-0 tablet:flex min-w-[70px] w-[70px] max-w-[70px] items-center"
-              size="1"
-            >
-              {badgeLabel}
-            </Badge>
-            <HStack align="center">
-              <TxIcon status="Success" type="Contract" />
-              <VStack gap="1">
-                <Text className="font-medium">Contract Created</Text>
-                <Address
-                  prefix="Id:"
-                  value={contractId}
-                  linkProps={{
-                    as: NextLink,
-                    href: Routes.contractAssets(contractId),
-                  }}
-                />
-              </VStack>
-            </HStack>
-          </Flex>
-        </Card.Header>
-      </Card>
-    );
-  },
-});
-
-export function TxOutput({ output, ...props }: TxOutputProps) {
+function _TxOutput({ output, ...props }: TxOutputProps) {
   if (
     isOutput<GQLVariableOutput>(output, 'VariableOutput') ||
     isOutput<GQLChangeOutput>(output, 'ChangeOutput') ||
@@ -165,13 +25,4 @@ export function TxOutput({ output, ...props }: TxOutputProps) {
   return null;
 }
 
-const styles = tv({
-  slots: {
-    header:
-      'group gap-2 flex flex-col tablet:flex-row items-start tablet:items-center',
-    amount: 'flex items-center gap-2 ml-14 tablet:ml-0',
-    content: 'gap-4 justify-between items-center flex-1',
-    icon: 'transition-transform group-data-[state=closed]:hover:rotate-180 group-data-[state=open]:rotate-180',
-    utxos: 'bg-gray-2 mx-4 py-3 px-4 rounded',
-  },
-});
+export const TxOutput = memo(_TxOutput);

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutput.tsx
@@ -2,12 +2,14 @@ import type {
   GQLChangeOutput,
   GQLCoinOutput,
   GQLContractCreated,
+  GQLContractOutput,
   GQLVariableOutput,
 } from '@fuel-explorer/graphql';
 import { memo } from 'react';
 import { isOutput } from './TxOutput.utils';
 import { TxOutputCoin } from './TxOutputCoin';
 import { TxOutputContractCreated } from './TxOutputContractCreated';
+import { TxOutputContractOutput } from './TxOutputContractOutput';
 import type { TxOutputProps } from './types';
 
 function _TxOutput({ output, ...props }: TxOutputProps) {
@@ -20,6 +22,9 @@ function _TxOutput({ output, ...props }: TxOutputProps) {
   }
   if (isOutput<GQLContractCreated>(output, 'ContractCreated')) {
     return <TxOutputContractCreated output={output} {...props} />;
+  }
+  if (isOutput<GQLContractOutput>(output, 'ContractOutput')) {
+    return <TxOutputContractOutput output={output} {...props} />;
   }
 
   return null;

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputCoin.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputCoin.tsx
@@ -1,0 +1,79 @@
+import type {
+  GQLChangeOutput,
+  GQLCoinOutput,
+  GQLVariableOutput,
+} from '@fuel-explorer/graphql';
+import {
+  Address,
+  Badge,
+  Card,
+  Flex,
+  HStack,
+  Icon,
+  createComponent,
+  cx,
+} from '@fuels/ui';
+import { IconArrowUp } from '@tabler/icons-react';
+import { bn } from 'fuels';
+import NextLink from 'next/link';
+import { Routes } from '~/routes';
+import { AssetItem } from '~/systems/Asset/components/AssetItem/AssetItem';
+import { Amount } from '~/systems/Core/components/Amount/Amount';
+import { txIconTypeMap, typeNameMap } from './constants';
+import { styles } from './styles';
+import type { TxOutputProps } from './types';
+
+export const TxOutputCoin = createComponent<
+  TxOutputProps<GQLChangeOutput | GQLCoinOutput | GQLVariableOutput>,
+  typeof Card
+>({
+  id: 'TxOutputCoin',
+  render: (_, { output, ...props }) => {
+    const classes = styles();
+    if (!output.assetId) return null;
+    const assetId = output.assetId;
+    const amount = output.amount;
+    const badgeLabel = typeNameMap?.[output?.__typename] ?? 'UNKNOWN';
+    const txIconTypeFallback = txIconTypeMap?.[output?.__typename] ?? 'Mint';
+
+    return (
+      <Card {...props} className={cx('py-3', props.className)}>
+        <Card.Header className={classes.header()}>
+          <Badge
+            color="gray"
+            className="font-mono justify-center ml-14 tablet:ml-0 tablet:flex min-w-[70px] w-[70px] max-w-[70px] items-center"
+            size="1"
+          >
+            {badgeLabel}
+          </Badge>
+          <Flex className={classes.content()}>
+            <AssetItem
+              assetId={assetId}
+              txIconTypeFallback={txIconTypeFallback}
+            >
+              <Address
+                prefix="To:"
+                value={output.to || ''}
+                linkProps={{
+                  as: NextLink,
+                  href: Routes.accountAssets(output.to!),
+                }}
+              />
+            </AssetItem>
+          </Flex>
+          <HStack className={classes.amount()}>
+            <Icon icon={IconArrowUp} className="text-success" />
+            {!!amount && (
+              <Amount
+                hideSymbol
+                hideIcon
+                assetId={assetId}
+                value={bn(amount)}
+              />
+            )}
+          </HStack>
+        </Card.Header>
+      </Card>
+    );
+  },
+});

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputCoin.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputCoin.tsx
@@ -34,7 +34,7 @@ export const TxOutputCoin = createComponent<
     const assetId = output.assetId;
     const amount = output.amount;
     const badgeLabel = typeNameMap?.[output?.__typename] ?? 'UNKNOWN';
-    const txIconTypeFallback = txIconTypeMap?.[output?.__typename] ?? 'Mint';
+    const txIconType = txIconTypeMap?.[output?.__typename] ?? 'Mint';
 
     return (
       <Card {...props} className={cx('py-3', props.className)}>
@@ -47,10 +47,7 @@ export const TxOutputCoin = createComponent<
             {badgeLabel}
           </Badge>
           <Flex className={classes.content()}>
-            <AssetItem
-              assetId={assetId}
-              txIconTypeFallback={txIconTypeFallback}
-            >
+            <AssetItem assetId={assetId} txIconTypeFallback={txIconType}>
               <Address
                 prefix="To:"
                 value={output.to || ''}

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputCoin.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputCoin.tsx
@@ -47,7 +47,11 @@ export const TxOutputCoin = createComponent<
             {badgeLabel}
           </Badge>
           <Flex className={classes.content()}>
-            <AssetItem assetId={assetId} txIconTypeFallback={txIconType}>
+            <AssetItem
+              assetId={assetId}
+              txIconTypeFallback={txIconType}
+              prefix="Asset:"
+            >
               <Address
                 prefix="To:"
                 value={output.to || ''}

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputContractCreated.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputContractCreated.tsx
@@ -1,0 +1,62 @@
+import type { GQLContractCreated } from '@fuel-explorer/graphql';
+import {
+  Address,
+  Badge,
+  Card,
+  Flex,
+  HStack,
+  Text,
+  VStack,
+  createComponent,
+  cx,
+} from '@fuels/ui';
+
+import NextLink from 'next/link';
+import { Routes } from '~/routes';
+
+import { TxIcon } from '../TxIcon/TxIcon';
+import { typeNameMap } from './constants';
+import { styles } from './styles';
+import type { TxOutputProps } from './types';
+
+export const TxOutputContractCreated = createComponent<
+  TxOutputProps<GQLContractCreated>,
+  typeof Card
+>({
+  id: 'TxOutputContractCreated',
+  render: (_, { output, ...props }) => {
+    const classes = styles();
+    const contractId = output.contract;
+    const badgeLabel = typeNameMap?.[output?.__typename] ?? 'UNKNOWN';
+
+    return (
+      <Card {...props} className={cx('py-3', props.className)}>
+        <Card.Header className={classes.header()}>
+          <Flex className={classes.content()}>
+            <Badge
+              color="gray"
+              className="font-mono justify-center ml-14 tablet:ml-0 tablet:flex min-w-[70px] w-[70px] max-w-[70px] items-center"
+              size="1"
+            >
+              {badgeLabel}
+            </Badge>
+            <HStack align="center">
+              <TxIcon status="Success" type="Contract" />
+              <VStack gap="1">
+                <Text className="font-medium">Contract Created</Text>
+                <Address
+                  prefix="Id:"
+                  value={contractId}
+                  linkProps={{
+                    as: NextLink,
+                    href: Routes.contractAssets(contractId),
+                  }}
+                />
+              </VStack>
+            </HStack>
+          </Flex>
+        </Card.Header>
+      </Card>
+    );
+  },
+});

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputContractCreated.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputContractCreated.tsx
@@ -15,7 +15,7 @@ import NextLink from 'next/link';
 import { Routes } from '~/routes';
 
 import { TxIcon } from '../TxIcon/TxIcon';
-import { typeNameMap } from './constants';
+import { txIconTypeMap, typeNameMap } from './constants';
 import { styles } from './styles';
 import type { TxOutputProps } from './types';
 
@@ -28,6 +28,7 @@ export const TxOutputContractCreated = createComponent<
     const classes = styles();
     const contractId = output.contract;
     const badgeLabel = typeNameMap?.[output?.__typename] ?? 'UNKNOWN';
+    const txIconType = txIconTypeMap?.[output?.__typename] ?? 'Unknown';
 
     return (
       <Card {...props} className={cx('py-3', props.className)}>
@@ -41,7 +42,7 @@ export const TxOutputContractCreated = createComponent<
               {badgeLabel}
             </Badge>
             <HStack align="center">
-              <TxIcon status="Success" type="Contract" />
+              <TxIcon status="Success" type={txIconType} />
               <VStack gap="1">
                 <Text className="font-medium">Contract Created</Text>
                 <Address

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputContractOutput.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/TxOutputContractOutput.tsx
@@ -1,0 +1,49 @@
+import type { GQLContractOutput } from '@fuel-explorer/graphql';
+import { Badge, Collapsible, Flex, Text, createComponent, cx } from '@fuels/ui';
+
+import { TxIcon } from '../TxIcon/TxIcon';
+import { txIconTypeMap, typeNameMap } from './constants';
+import { styles } from './styles';
+import type { TxOutputProps } from './types';
+
+import { IconInputSearch } from '@tabler/icons-react';
+
+export const TxOutputContractOutput = createComponent<
+  TxOutputProps<GQLContractOutput>,
+  typeof Collapsible
+>({
+  id: 'TxOutputContractOutput',
+  render: (_, { output, ...props }) => {
+    const classes = styles();
+    const badgeLabel = typeNameMap?.[output?.__typename] ?? 'UNKNOWN';
+    const txIconType = txIconTypeMap?.[output?.__typename] ?? 'Unknown';
+    return (
+      <Collapsible {...props} className={cx('py-3', props.className)}>
+        <Collapsible.Header className={classes.header()}>
+          <Flex className={classes.content({ reversed: true })}>
+            <Badge
+              color="gray"
+              className="font-mono justify-center mr-auto tablet:mr-0 tablet:flex min-w-[70px] w-[70px] max-w-[70px] items-center"
+              size="1"
+            >
+              {badgeLabel}
+            </Badge>
+
+            <TxIcon status="Submitted" type={txIconType} className="mr-auto" />
+          </Flex>
+        </Collapsible.Header>
+        <Collapsible.Content>
+          <Collapsible.Title leftIcon={IconInputSearch} iconColor="text-icon">
+            Input
+          </Collapsible.Title>
+          <Collapsible.Body className={classes.contractOutputContent()}>
+            <Text className={classes.contractOutputText()}>Index: </Text>
+            <Text className={classes.contractOutputText()}>
+              {output.inputIndex}
+            </Text>
+          </Collapsible.Body>
+        </Collapsible.Content>
+      </Collapsible>
+    );
+  },
+});

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/constants.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/constants.ts
@@ -1,0 +1,24 @@
+import type { GQLTransactionOutputFragment } from '@fuel-explorer/graphql';
+import type { TxIconType } from '~/systems/Transaction/types';
+
+export const typeNameMap: Record<
+  GQLTransactionOutputFragment['__typename'],
+  string
+> = {
+  ContractOutput: 'OUTPUT',
+  ContractCreated: 'CREATED',
+  VariableOutput: 'VARIABLE',
+  ChangeOutput: 'CHANGE',
+  CoinOutput: 'COIN',
+};
+
+export const txIconTypeMap: Record<
+  GQLTransactionOutputFragment['__typename'],
+  TxIconType
+> = {
+  ContractOutput: 'Contract',
+  ContractCreated: 'Contract Created',
+  VariableOutput: 'Mint',
+  ChangeOutput: 'Wallet',
+  CoinOutput: 'Wallet',
+};

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/styles.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/styles.ts
@@ -8,5 +8,17 @@ export const styles = tv({
     content: 'gap-4 justify-between items-center flex-1',
     icon: 'transition-transform group-data-[state=closed]:hover:rotate-180 group-data-[state=open]:rotate-180',
     utxos: 'bg-gray-2 mx-4 py-3 px-4 rounded',
+    contractOutputContent: [
+      'flex flex-row flex-1 p-0 py-2 px-4 gap-2',
+      'last:rounded-b-sm',
+    ],
+    contractOutputText: 'text-[0.86em] text-secondary font-mono leading-none',
+  },
+  variants: {
+    reversed: {
+      true: {
+        content: 'flex-row-reverse tablet:flex-row',
+      },
+    },
   },
 });

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/styles.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/styles.ts
@@ -1,0 +1,12 @@
+import { tv } from 'tailwind-variants';
+
+export const styles = tv({
+  slots: {
+    header:
+      'group gap-2 flex flex-col tablet:flex-row items-start tablet:items-center',
+    amount: 'flex items-center gap-2 ml-14 tablet:ml-0',
+    content: 'gap-4 justify-between items-center flex-1',
+    icon: 'transition-transform group-data-[state=closed]:hover:rotate-180 group-data-[state=open]:rotate-180',
+    utxos: 'bg-gray-2 mx-4 py-3 px-4 rounded',
+  },
+});

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/types.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/types.ts
@@ -1,0 +1,6 @@
+import type { GQLTransactionOutputFragment } from '@fuel-explorer/graphql';
+import type { CardProps } from '@fuels/ui';
+
+export type TxOutputProps<T = GQLTransactionOutputFragment> = CardProps & {
+  output: T;
+};

--- a/packages/app-explorer/src/systems/Transaction/component/TxScreen/TxScreenSimple.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScreen/TxScreenSimple.tsx
@@ -32,7 +32,7 @@ import { AssetItem } from '~/systems/Asset/components/AssetItem/AssetItem';
 import { CardInfo } from '../../../Core/components/CardInfo/CardInfo';
 import { TxInput } from '../../component/TxInput/TxInput';
 import { TxOutput } from '../../component/TxOutput/TxOutput';
-import type { TransactionNode, TxStatus } from '../../types';
+import type { TransactionNode, TxIconType, TxStatus } from '../../types';
 import { TX_INTENT_MAP, TxIcon } from '../TxIcon/TxIcon';
 import { TxScripts } from '../TxScripts/TxScripts';
 
@@ -60,7 +60,7 @@ export function TxScreenSimple({ transaction: tx, isLoading }: TxScreenProps) {
             loadingEl={<LoadingBox className="w-11 h-11 rounded-full" />}
             regularEl={
               <TxIcon
-                type={title}
+                type={title as TxIconType}
                 size="lg"
                 status={
                   tx?.hasPredicate ? 'Info' : (tx?.statusType as TxStatus)

--- a/packages/app-explorer/src/systems/Transaction/component/TxScreen/TxScreenSimple.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScreen/TxScreenSimple.tsx
@@ -295,7 +295,7 @@ function MintOutputs({
       <Card className="pb-3">
         <Card.Header className={classes.header()}>
           {tx.mintAssetId && (
-            <AssetItem assetId={tx.mintAssetId}>
+            <AssetItem assetId={tx.mintAssetId} prefix="Asset:">
               <Address
                 prefix="Id:"
                 value={tx.mintAssetId}

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptAmount.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptAmount.tsx
@@ -21,11 +21,11 @@ export function TxReceiptAmount() {
           value={amount}
           className="text-xs tablet:text-sm"
         />
-        {!!contract && (
+        {!!contract && !!assetId && (
           <Address
             iconSize={14}
             value={assetId}
-            className="text-xs tablet:text-sm font-mono"
+            className="text-xs tablet:text-sm font-mono hidden tablet:block"
             linkProps={{
               as: NextLink,
               href: `/contract/${contract}/assets`,

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptAmount.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptAmount.tsx
@@ -14,22 +14,24 @@ export function TxReceiptAmount() {
 
   return (
     amount.gt(0) && (
-      <VStack className="gap-1 items-end mobile:max-tablet:hidden">
+      <VStack className="gap-1 items-end self-end">
         <Amount
           iconSize={16}
           assetId={assetId}
           value={amount}
           className="text-xs tablet:text-sm"
         />
-        <Address
-          iconSize={14}
-          value={assetId}
-          className="text-xs tablet:text-sm font-mono"
-          linkProps={{
-            as: NextLink,
-            href: `/contract/${contract}/assets`,
-          }}
-        />
+        {!!contract && (
+          <Address
+            iconSize={14}
+            value={assetId}
+            className="text-xs tablet:text-sm font-mono"
+            linkProps={{
+              as: NextLink,
+              href: `/contract/${contract}/assets`,
+            }}
+          />
+        )}
       </VStack>
     )
   );

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptAmount.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptAmount.tsx
@@ -1,38 +1,44 @@
 import { Address, VStack } from '@fuels/ui';
+import clsx from 'clsx';
 import { bn } from 'fuels';
 import NextLink from 'next/link';
 import { useContext } from 'react';
 import { Amount } from '~/systems/Core/components/Amount/Amount';
 import { ReceiptContext } from '~/systems/Transaction/component/TxScripts/context';
 
-export function TxReceiptAmount() {
+export function TxReceiptAmount({
+  className,
+  singleMode,
+}: { className?: string; singleMode?: boolean }) {
   const { receipt: item } = useContext(ReceiptContext);
   const receipt = item?.item;
   const assetId = receipt?.assetId ?? '';
   const amount = bn(receipt?.amount);
   const contract = receipt?.to ?? receipt?.contractId ?? null;
 
+  if (!amount?.gt?.(0)) {
+    return null;
+  }
+
   return (
-    amount.gt(0) && (
-      <VStack className="gap-1 items-end self-end">
-        <Amount
-          iconSize={16}
-          assetId={assetId}
-          value={amount}
-          className="text-xs tablet:text-sm"
+    <VStack className={clsx('gap-1 items-end self-end', className)}>
+      <Amount
+        iconSize={16}
+        assetId={assetId}
+        value={amount}
+        className="text-xs tablet:text-sm"
+      />
+      {!singleMode && !!contract && !!assetId && (
+        <Address
+          iconSize={14}
+          value={assetId}
+          className="text-xs tablet:text-sm font-mono hidden tablet:block"
+          linkProps={{
+            as: NextLink,
+            href: `/contract/${contract}/assets`,
+          }}
         />
-        {!!contract && !!assetId && (
-          <Address
-            iconSize={14}
-            value={assetId}
-            className="text-xs tablet:text-sm font-mono hidden tablet:block"
-            linkProps={{
-              as: NextLink,
-              href: `/contract/${contract}/assets`,
-            }}
-          />
-        )}
-      </VStack>
-    )
+      )}
+    </VStack>
   );
 }

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptAmount.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptAmount.tsx
@@ -1,3 +1,4 @@
+import type { GQLReceipt } from '@fuel-explorer/graphql/sdk';
 import { Address, VStack } from '@fuels/ui';
 import clsx from 'clsx';
 import { bn } from 'fuels';
@@ -9,11 +10,17 @@ import { ReceiptContext } from '~/systems/Transaction/component/TxScripts/contex
 export function TxReceiptAmount({
   className,
   singleMode,
-}: { className?: string; singleMode?: boolean }) {
+  valueField,
+}: {
+  className?: string;
+  singleMode?: boolean;
+  valueField?: keyof GQLReceipt;
+}) {
   const { receipt: item } = useContext(ReceiptContext);
   const receipt = item?.item;
   const assetId = receipt?.assetId ?? '';
-  const amount = bn(receipt?.amount);
+  const amountField = (valueField && receipt?.[valueField]) || receipt?.amount;
+  const amount = bn(amountField);
   const contract = receipt?.to ?? receipt?.contractId ?? null;
 
   if (!amount?.gt?.(0)) {

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptBadge/TxReceiptBadge.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptBadge/TxReceiptBadge.tsx
@@ -9,10 +9,13 @@ export function TxReceiptBadge() {
   const type = receipt?.item?.receiptType ?? 'UNKNOWN';
   const color = getBadgeColor(Boolean(hasPanic), receipt?.item);
   return (
-    <div>
-      <Badge size="1" className="font-mono" variant="ghost" color={color}>
-        {type}
-      </Badge>
-    </div>
+    <Badge
+      size="1"
+      className="font-mono ml-14 tablet:ml-0 self-start tablet:self-center justify-center"
+      variant="ghost"
+      color={color}
+    >
+      {type}
+    </Badge>
   );
 }

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/TxReceiptHeader.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/TxReceiptHeader.tsx
@@ -1,39 +1,65 @@
 import { GQLReceiptType } from '@fuel-explorer/graphql/sdk';
-import { Collapsible, VStack } from '@fuels/ui';
+import { Collapsible, Flex, HStack, VStack } from '@fuels/ui';
 import { useContext } from 'react';
 import { TxOperationHeader } from '~/systems/Transaction/component/TxScripts/TxOperationHeader';
 import { TxReceiptAmount } from '~/systems/Transaction/component/TxScripts/TxReceiptAmount';
 import { TxReceiptBadge } from '~/systems/Transaction/component/TxScripts/TxReceiptBadge/TxReceiptBadge';
 import { ReceiptContext } from '~/systems/Transaction/component/TxScripts/context';
 
+import { TxIcon } from '~/systems/Transaction/component/TxIcon/TxIcon';
+import { TxIconType } from '~/systems/Transaction/types';
 import { RECEIPT_FIELDS_MAP } from './constants';
 import { styles } from './styles';
+
+const TX_ICON_MAP: Record<GQLReceiptType, TxIconType> = {
+  TRANSFER_OUT: 'Transfer',
+  TRANSFER: 'Transfer',
+  SCRIPT_RESULT: 'Script',
+  REVERT: 'ContractCall',
+  RETURN_DATA: 'Message',
+  RETURN: 'Message',
+  PANIC: 'Message',
+  MINT: 'Mint',
+  MESSAGE_OUT: 'Message',
+  LOG_DATA: 'Message',
+  LOG: 'Message',
+  CALL: 'ContractCall',
+  BURN: 'Burn',
+};
 
 export function TxReceiptHeader() {
   const { receipt: item } = useContext(ReceiptContext);
   const receipt = item?.item;
   const classes = styles();
   const type = (receipt?.receiptType ?? 'UNKNOWN') as GQLReceiptType;
+  const txIcon: TxIconType = TX_ICON_MAP?.[type] ?? 'Message';
   const fields = RECEIPT_FIELDS_MAP[type] || [];
 
   return (
     <Collapsible.Header className={classes.header()}>
-      <TxReceiptBadge />
-      <VStack className="flex-1 gap-[2px]">
-        {!fields?.length && <TxReceiptBadge />}
-
-        {fields?.map((field, index) => (
-          <TxOperationHeader
-            key={`operation-header-${field.type}-${field.requiredField ?? ''}-${
-              field.field
-            }-${field.fieldFallback}`}
-            field={field}
-            index={index}
-            receipt={receipt}
+      <Flex className="gap-2 flex-col tablet:flex-row w-full">
+        <TxReceiptBadge />
+        <HStack className="flex-1 gap-4 items-center w-full">
+          <TxIcon
+            type={txIcon}
+            status={type === GQLReceiptType.Panic ? 'Failure' : 'Submitted'}
           />
-        ))}
-      </VStack>
-      <TxReceiptAmount />
+
+          <VStack className="flex-1 gap-[2px]">
+            {fields?.map((field, index) => (
+              <TxOperationHeader
+                key={`operation-header-${field.type}-${
+                  field.requiredField ?? ''
+                }-${field.field}-${field.fieldFallback}`}
+                field={field}
+                index={index}
+                receipt={receipt}
+              />
+            ))}
+          </VStack>
+          <TxReceiptAmount />
+        </HStack>
+      </Flex>
     </Collapsible.Header>
   );
 }

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/TxReceiptHeader.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/TxReceiptHeader.tsx
@@ -57,8 +57,12 @@ export function TxReceiptHeader() {
               />
             ))}
           </VStack>
-          <TxReceiptAmount />
+          <TxReceiptAmount className="hidden tablet:block" />
         </HStack>
+        <TxReceiptAmount
+          className="block tablet:hidden self-start mr-auto ml-14"
+          singleMode
+        />
       </Flex>
     </Collapsible.Header>
   );

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/constants.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/constants.ts
@@ -45,10 +45,14 @@ export const RECEIPT_FIELDS_MAP: Record<
       requiredField: 'subId',
     },
     {
-      label: 'Asset:',
+      label: 'Id:',
       type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
-      field: 'contractId',
-      hrefFactory: Routes.contractAssets,
+      field: 'id',
+    },
+    {
+      label: 'Sub Id:',
+      type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
+      field: 'subId',
     },
   ],
   [GQLReceiptType.TransferOut]: [

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/constants.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/constants.ts
@@ -10,7 +10,6 @@ export const RECEIPT_FIELDS_MAP: Record<
   Array<ReceiptHeaderOperation>
 > = {
   [GQLReceiptType.Call]: [
-    { label: 'Method', field: 'param1' },
     {
       label: 'Contract:',
       type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
@@ -18,6 +17,7 @@ export const RECEIPT_FIELDS_MAP: Record<
       fieldFallback: 'contractId',
       hrefFactory: Routes.contractAssets,
     },
+    { label: 'Method', field: 'param1' },
   ],
   [GQLReceiptType.Mint]: [
     {
@@ -125,10 +125,7 @@ export const RECEIPT_FIELDS_MAP: Record<
     { label: 'PC', field: 'pc' },
     { label: 'Data:', field: 'data' },
   ],
-  [GQLReceiptType.Return]: [
-    { label: 'Value:', field: 'val' },
-    { label: 'PC', field: 'pc' },
-  ],
+  [GQLReceiptType.Return]: [{ label: 'Value:', field: 'val' }],
   [GQLReceiptType.ScriptResult]: [
     { label: 'Gas Used:', field: 'gasUsed' },
     { label: 'Result:', field: 'result' },

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/constants.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/constants.ts
@@ -27,10 +27,14 @@ export const RECEIPT_FIELDS_MAP: Record<
       requiredField: 'subId',
     },
     {
-      label: 'Asset:',
+      label: 'Id:',
       type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
-      field: 'contractId',
-      hrefFactory: Routes.contractAssets,
+      field: 'id',
+    },
+    {
+      label: 'SubId:',
+      type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
+      field: 'subId',
     },
   ],
   [GQLReceiptType.Burn]: [
@@ -49,7 +53,7 @@ export const RECEIPT_FIELDS_MAP: Record<
   ],
   [GQLReceiptType.TransferOut]: [
     {
-      label: 'ID:',
+      label: 'Id:',
       type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
       field: 'id',
     },
@@ -63,7 +67,7 @@ export const RECEIPT_FIELDS_MAP: Record<
   ],
   [GQLReceiptType.Transfer]: [
     {
-      label: 'ID:',
+      label: 'Id:',
       type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
       field: 'id',
     },
@@ -102,7 +106,7 @@ export const RECEIPT_FIELDS_MAP: Record<
   [GQLReceiptType.Panic]: [
     { label: 'Reason:', field: 'reason' },
     {
-      label: 'Contract ID:',
+      label: 'Contract Id:',
       type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
       field: 'contractId',
       hrefFactory: Routes.contractAssets,
@@ -111,7 +115,7 @@ export const RECEIPT_FIELDS_MAP: Record<
   [GQLReceiptType.Revert]: [
     { label: 'Reason:', field: 'reason' },
     {
-      label: 'Contract ID:',
+      label: 'Contract Id:',
       type: ReceiptHeaderOperationDataType.HEX_ADDRESS,
       field: 'contractId',
       hrefFactory: Routes.contractAssets,

--- a/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/types.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxScripts/TxReceiptHeader/types.ts
@@ -1,4 +1,4 @@
-import type { GQLReceipt } from '@fuel-explorer/graphql';
+import type { GQLReceipt } from '@fuel-explorer/graphql/sdk';
 
 export enum ReceiptHeaderOperationDataType {
   DEFAULT = 'DEFAULT',
@@ -17,7 +17,8 @@ interface ReceiptHeaderOperationBase {
   hrefFactory?: (value: string) => string;
 }
 
-interface ReceiptHeaderOperationAmount extends ReceiptHeaderOperationBase {
+export interface ReceiptHeaderOperationAmount
+  extends ReceiptHeaderOperationBase {
   label?: never;
   type: ReceiptHeaderOperationDataType.AMOUNT;
   field?: keyof GQLReceipt;

--- a/packages/app-explorer/src/systems/Transaction/types.ts
+++ b/packages/app-explorer/src/systems/Transaction/types.ts
@@ -1,4 +1,4 @@
-import type { GQLTransactionItemFragment } from '@fuel-explorer/graphql';
+import type { GQLTransactionItemFragment } from '@fuel-explorer/graphql/sdk';
 import type { ViewModes } from '../Core/components/ViewMode/constants';
 
 export type TxRouteParams = {

--- a/packages/graphql/src/domain/Transaction/ReceiptsParserAdapter.ts
+++ b/packages/graphql/src/domain/Transaction/ReceiptsParserAdapter.ts
@@ -45,16 +45,19 @@ export default class ReceiptsParserAdapter {
         top.receipts.push({ item: group.item });
         top.receipts.push(...group.receipts);
         groups.push(top);
+      } else if (group.type === 'SCRIPT_RESULT') {
+        const top = {
+          type: 'FINAL_RESULT',
+          receipts: [] as any,
+        };
+        top.receipts.push({ item: group.item });
+        if (group.receipts) top.receipts.push(...group.receipts);
+        groups.push(top);
       } else {
-        if (group.type === 'SCRIPT_RESULT') {
-          const top = {
-            type: 'FINAL_RESULT',
-            receipts: [] as any,
-          };
-          top.receipts.push({ item: group.item });
-          if (group.receipts) top.receipts.push(...group.receipts);
-          groups.push(top);
-        }
+        groups.push({
+          type: group.receiptType,
+          receipts: [group.item],
+        });
       }
     }
     return groups;

--- a/packages/graphql/src/domain/Transaction/ReceiptsParserAdapter.ts
+++ b/packages/graphql/src/domain/Transaction/ReceiptsParserAdapter.ts
@@ -1,3 +1,4 @@
+import { GroupedReceiptsFactory } from '~/domain/Transaction/factories/GroupedReceiptsFactory';
 import ReceiptsParser from './ReceiptsParser';
 
 export default class ReceiptsParserAdapter {
@@ -26,39 +27,12 @@ export default class ReceiptsParserAdapter {
         pointer = lastPointer[next.indent];
       }
     }
+
     const groups = [];
+
     for (const group of data) {
-      if (group.type === 'CALL') {
-        const top = {
-          type: 'FROM_CONTRACT',
-          receipts: [] as any,
-        };
-        top.receipts.push({ item: group.item });
-        top.receipts.push(...group.receipts);
-        groups.push(top);
-      }
-      if (group.type === 'RETURN') {
-        const top = {
-          type: 'FINAL_RESULT',
-          receipts: [] as any,
-        };
-        top.receipts.push({ item: group.item });
-        top.receipts.push(...group.receipts);
-        groups.push(top);
-      } else if (group.type === 'SCRIPT_RESULT') {
-        const top = {
-          type: 'FINAL_RESULT',
-          receipts: [] as any,
-        };
-        top.receipts.push({ item: group.item });
-        if (group.receipts) top.receipts.push(...group.receipts);
-        groups.push(top);
-      } else {
-        groups.push({
-          type: group.item.receiptType,
-          receipts: [group.item],
-        });
-      }
+      const groupedData = GroupedReceiptsFactory(group);
+      groupedData && groups.push(groupedData);
     }
     return groups;
   }

--- a/packages/graphql/src/domain/Transaction/ReceiptsParserAdapter.ts
+++ b/packages/graphql/src/domain/Transaction/ReceiptsParserAdapter.ts
@@ -55,7 +55,7 @@ export default class ReceiptsParserAdapter {
         groups.push(top);
       } else {
         groups.push({
-          type: group.receiptType,
+          type: group.item.receiptType,
           receipts: [group.item],
         });
       }

--- a/packages/graphql/src/domain/Transaction/TransactionEntity.ts
+++ b/packages/graphql/src/domain/Transaction/TransactionEntity.ts
@@ -55,12 +55,12 @@ export class TransactionEntity extends Entity<
     // Should show for other status like FailureStatus?
     // @ts-ignore
     if (item.status?.receipts) {
-      // @ts-ignore
-      const receipts = item.status?.receipts || [];
-      operations = parser.parse(receipts) as any;
-      operations = operations.map((operation: any) =>
-        OperationEntity.create(operation, item._id || '', item.id),
-      );
+      operations = parser
+        // @ts-ignore
+        .parse(item.status?.receipts ?? [])
+        .map((operation: any) =>
+          OperationEntity.create(operation, item._id || '', item.id),
+        );
     }
     const props = {
       id,

--- a/packages/graphql/src/domain/Transaction/factories/GroupedReceiptsFactory.ts
+++ b/packages/graphql/src/domain/Transaction/factories/GroupedReceiptsFactory.ts
@@ -1,0 +1,17 @@
+const GroupTypeMap = {
+  CALL: 'FROM_CONTRACT',
+  RETURN: 'FINAL_RESULT',
+  SCRIPT_RESULT: 'FINAL_RESULT',
+};
+
+export function GroupedReceiptsFactory(group: any) {
+  const type =
+    GroupTypeMap[group.type] ?? group?.item?.receiptType ?? 'UNKNOWN';
+  const top = {
+    type,
+    receipts: [] as any,
+  };
+  top.receipts.push({ item: group.item });
+  group.receipts && top.receipts.push(...group.receipts);
+  return top;
+}

--- a/packages/graphql/src/domain/Transaction/factories/GroupedReceiptsFactory.ts
+++ b/packages/graphql/src/domain/Transaction/factories/GroupedReceiptsFactory.ts
@@ -1,6 +1,12 @@
-import { GQLOperationType } from '~/graphql/generated/sdk-provider';
+import {
+  GQLOperationType,
+  GQLReceiptType,
+} from '~/graphql/generated/sdk-provider';
 
-const GroupTypeMap = {
+const GroupTypeMap: Record<
+  GQLReceiptType.Call | GQLReceiptType.Return | GQLReceiptType.ScriptResult,
+  Omit<GQLOperationType, 'ROOTLESS'>
+> = {
   CALL: 'FROM_CONTRACT',
   RETURN: 'FINAL_RESULT',
   SCRIPT_RESULT: 'FINAL_RESULT',

--- a/packages/graphql/src/domain/Transaction/factories/GroupedReceiptsFactory.ts
+++ b/packages/graphql/src/domain/Transaction/factories/GroupedReceiptsFactory.ts
@@ -1,3 +1,5 @@
+import { GQLOperationType } from '~/graphql/generated/sdk-provider';
+
 const GroupTypeMap = {
   CALL: 'FROM_CONTRACT',
   RETURN: 'FINAL_RESULT',
@@ -5,8 +7,7 @@ const GroupTypeMap = {
 };
 
 export function GroupedReceiptsFactory(group: any) {
-  const type =
-    GroupTypeMap[group.type] ?? group?.item?.receiptType ?? 'UNKNOWN';
+  const type = GroupTypeMap[group.type] ?? GQLOperationType.Rootless;
   const top = {
     type,
     receipts: [] as any,

--- a/packages/graphql/src/graphql/generated/sdk-provider.ts
+++ b/packages/graphql/src/graphql/generated/sdk-provider.ts
@@ -1,38 +1,51 @@
+import { GraphQLError, print } from 'graphql';
 import type { GraphQLClient, RequestOptions } from 'graphql-request';
-import { GraphQLError, print } from 'graphql'
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
-export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
+export type Exact<T extends { [key: string]: unknown }> = {
+  [K in keyof T]: T[K];
+};
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]?: Maybe<T[SubKey]>;
+};
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+  [SubKey in K]: Maybe<T[SubKey]>;
+};
+export type MakeEmpty<
+  T extends { [key: string]: unknown },
+  K extends keyof T,
+> = { [_ in K]?: never };
+export type Incremental<T> =
+  | T
+  | {
+      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
+    };
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string; }
-  String: { input: string; output: string; }
-  Boolean: { input: boolean; output: boolean; }
-  Int: { input: number; output: number; }
-  Float: { input: number; output: number; }
-  Address: { input: string; output: string; }
-  AssetId: { input: string; output: string; }
-  BlockId: { input: string; output: string; }
-  Bytes32: { input: string; output: string; }
-  ContractId: { input: string; output: string; }
-  HexString: { input: string; output: string; }
-  Nonce: { input: string; output: string; }
-  RelayedTransactionId: { input: string; output: string; }
-  Salt: { input: string; output: string; }
-  Signature: { input: string; output: string; }
-  Tai64Timestamp: { input: string; output: string; }
-  TransactionId: { input: string; output: string; }
-  TxPointer: { input: string; output: string; }
-  U16: { input: string; output: string; }
-  U32: { input: string; output: string; }
-  U64: { input: string; output: string; }
-  UtxoId: { input: string; output: string; }
+  ID: { input: string; output: string };
+  String: { input: string; output: string };
+  Boolean: { input: boolean; output: boolean };
+  Int: { input: number; output: number };
+  Float: { input: number; output: number };
+  Address: { input: string; output: string };
+  AssetId: { input: string; output: string };
+  BlockId: { input: string; output: string };
+  Bytes32: { input: string; output: string };
+  ContractId: { input: string; output: string };
+  HexString: { input: string; output: string };
+  Nonce: { input: string; output: string };
+  RelayedTransactionId: { input: string; output: string };
+  Salt: { input: string; output: string };
+  Signature: { input: string; output: string };
+  Tai64Timestamp: { input: string; output: string };
+  TransactionId: { input: string; output: string };
+  TxPointer: { input: string; output: string };
+  U16: { input: string; output: string };
+  U32: { input: string; output: string };
+  U64: { input: string; output: string };
+  UtxoId: { input: string; output: string };
 };
 
 export type GQLBalance = {
@@ -101,7 +114,7 @@ export type GQLBlockEdge = {
 };
 
 export enum GQLBlockVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 /** Breakpoint, defined as a tuple of contract ID and relative PC offset inside it */
@@ -198,7 +211,7 @@ export type GQLConsensusParametersPurpose = {
 };
 
 export enum GQLConsensusParametersVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 export type GQLContract = {
@@ -267,7 +280,7 @@ export type GQLContractParameters = {
 };
 
 export enum GQLContractParametersVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 export type GQLDependentCost = GQLHeavyOperation | GQLLightOperation;
@@ -296,7 +309,9 @@ export type GQLDryRunTransactionExecutionStatus = {
   status: GQLDryRunTransactionStatus;
 };
 
-export type GQLDryRunTransactionStatus = GQLDryRunFailureStatus | GQLDryRunSuccessStatus;
+export type GQLDryRunTransactionStatus =
+  | GQLDryRunFailureStatus
+  | GQLDryRunSuccessStatus;
 
 export type GQLEstimateGasPrice = {
   __typename: 'EstimateGasPrice';
@@ -330,7 +345,7 @@ export type GQLFeeParameters = {
 };
 
 export enum GQLFeeParametersVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 export type GQLGasCosts = {
@@ -450,7 +465,7 @@ export type GQLGasCosts = {
 };
 
 export enum GQLGasCostsVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 export type GQLGenesis = {
@@ -470,7 +485,10 @@ export type GQLGenesis = {
   transactionsRoot: Scalars['Bytes32']['output'];
 };
 
-export type GQLGroupedInput = GQLGroupedInputCoin | GQLGroupedInputContract | GQLGroupedInputMessage;
+export type GQLGroupedInput =
+  | GQLGroupedInputCoin
+  | GQLGroupedInputContract
+  | GQLGroupedInputMessage;
 
 export type GQLGroupedInputCoin = {
   __typename: 'GroupedInputCoin';
@@ -500,10 +518,13 @@ export type GQLGroupedInputMessage = {
 export enum GQLGroupedInputType {
   InputCoin = 'InputCoin',
   InputContract = 'InputContract',
-  InputMessage = 'InputMessage'
+  InputMessage = 'InputMessage',
 }
 
-export type GQLGroupedOutput = GQLGroupedOutputChanged | GQLGroupedOutputCoin | GQLGroupedOutputContractCreated;
+export type GQLGroupedOutput =
+  | GQLGroupedOutputChanged
+  | GQLGroupedOutputCoin
+  | GQLGroupedOutputContractCreated;
 
 export type GQLGroupedOutputChanged = {
   __typename: 'GroupedOutputChanged';
@@ -533,7 +554,7 @@ export type GQLGroupedOutputContractCreated = {
 export enum GQLGroupedOutputType {
   OutputChanged = 'OutputChanged',
   OutputCoin = 'OutputCoin',
-  OutputContractCreated = 'OutputContractCreated'
+  OutputContractCreated = 'OutputContractCreated',
 }
 
 export type GQLHeader = {
@@ -569,7 +590,7 @@ export type GQLHeader = {
 };
 
 export enum GQLHeaderVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 export type GQLHeavyOperation = {
@@ -688,7 +709,7 @@ export type GQLMessageProof = {
 export enum GQLMessageState {
   NotFound = 'NOT_FOUND',
   Spent = 'SPENT',
-  Unspent = 'UNSPENT'
+  Unspent = 'UNSPENT',
 }
 
 export type GQLMessageStatus = {
@@ -742,11 +763,9 @@ export type GQLMutation = {
   submit: GQLTransaction;
 };
 
-
 export type GQLMutationContinueTxArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type GQLMutationDryRunArgs = {
   gasPrice?: InputMaybe<Scalars['U64']['input']>;
@@ -754,46 +773,38 @@ export type GQLMutationDryRunArgs = {
   utxoValidation?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
-
 export type GQLMutationEndSessionArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type GQLMutationExecuteArgs = {
   id: Scalars['ID']['input'];
   op: Scalars['String']['input'];
 };
 
-
 export type GQLMutationProduceBlocksArgs = {
   blocksToProduce: Scalars['U32']['input'];
   startTimestamp?: InputMaybe<Scalars['Tai64Timestamp']['input']>;
 };
 
-
 export type GQLMutationResetArgs = {
   id: Scalars['ID']['input'];
 };
-
 
 export type GQLMutationSetBreakpointArgs = {
   breakpoint: GQLBreakpoint;
   id: Scalars['ID']['input'];
 };
 
-
 export type GQLMutationSetSingleSteppingArgs = {
   enable: Scalars['Boolean']['input'];
   id: Scalars['ID']['input'];
 };
 
-
 export type GQLMutationStartTxArgs = {
   id: Scalars['ID']['input'];
   txJson: Scalars['String']['input'];
 };
-
 
 export type GQLMutationSubmitArgs = {
   tx: Scalars['HexString']['input'];
@@ -825,14 +836,20 @@ export type GQLOperationReceipt = {
 export enum GQLOperationType {
   FinalResult = 'FINAL_RESULT',
   FromAccount = 'FROM_ACCOUNT',
-  FromContract = 'FROM_CONTRACT'
+  FromContract = 'FROM_CONTRACT',
+  Rootless = 'ROOTLESS',
 }
 
 export type GQLOperationsFilterInput = {
   transactionHash: Scalars['String']['input'];
 };
 
-export type GQLOutput = GQLChangeOutput | GQLCoinOutput | GQLContractCreated | GQLContractOutput | GQLVariableOutput;
+export type GQLOutput =
+  | GQLChangeOutput
+  | GQLCoinOutput
+  | GQLContractCreated
+  | GQLContractOutput
+  | GQLVariableOutput;
 
 /**
  * A separate `Breakpoint` type to be used as an output, as a single
@@ -911,7 +928,7 @@ export type GQLPredicateParameters = {
 };
 
 export enum GQLPredicateParametersVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 export type GQLProgramState = {
@@ -972,12 +989,10 @@ export type GQLQuery = {
   transactionsByOwner: GQLTransactionConnection;
 };
 
-
 export type GQLQueryBalanceArgs = {
   assetId: Scalars['AssetId']['input'];
   owner: Scalars['Address']['input'];
 };
-
 
 export type GQLQueryBalancesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -987,12 +1002,10 @@ export type GQLQueryBalancesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
 export type GQLQueryBlockArgs = {
   height?: InputMaybe<Scalars['U32']['input']>;
   id?: InputMaybe<Scalars['BlockId']['input']>;
 };
-
 
 export type GQLQueryBlocksArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1001,11 +1014,9 @@ export type GQLQueryBlocksArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
 export type GQLQueryCoinArgs = {
   utxoId: Scalars['UtxoId']['input'];
 };
-
 
 export type GQLQueryCoinsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1015,24 +1026,20 @@ export type GQLQueryCoinsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
 export type GQLQueryCoinsToSpendArgs = {
   excludedIds?: InputMaybe<GQLExcludeInput>;
   owner: Scalars['Address']['input'];
   queryPerAsset: Array<GQLSpendQueryElementInput>;
 };
 
-
 export type GQLQueryContractArgs = {
   id: Scalars['ContractId']['input'];
 };
-
 
 export type GQLQueryContractBalanceArgs = {
   asset: Scalars['AssetId']['input'];
   contract: Scalars['ContractId']['input'];
 };
-
 
 export type GQLQueryContractBalancesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1042,7 +1049,6 @@ export type GQLQueryContractBalancesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
 export type GQLQueryContractsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -1050,16 +1056,13 @@ export type GQLQueryContractsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
 export type GQLQueryEstimateGasPriceArgs = {
   blockHorizon?: InputMaybe<Scalars['U32']['input']>;
 };
 
-
 export type GQLQueryEstimatePredicatesArgs = {
   tx: Scalars['HexString']['input'];
 };
-
 
 export type GQLQueryMemoryArgs = {
   id: Scalars['ID']['input'];
@@ -1067,11 +1070,9 @@ export type GQLQueryMemoryArgs = {
   start: Scalars['U32']['input'];
 };
 
-
 export type GQLQueryMessageArgs = {
   nonce: Scalars['Nonce']['input'];
 };
-
 
 export type GQLQueryMessageProofArgs = {
   commitBlockHeight?: InputMaybe<Scalars['U32']['input']>;
@@ -1080,11 +1081,9 @@ export type GQLQueryMessageProofArgs = {
   transactionId: Scalars['TransactionId']['input'];
 };
 
-
 export type GQLQueryMessageStatusArgs = {
   nonce: Scalars['Nonce']['input'];
 };
-
 
 export type GQLQueryMessagesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1094,32 +1093,26 @@ export type GQLQueryMessagesArgs = {
   owner?: InputMaybe<Scalars['Address']['input']>;
 };
 
-
 export type GQLQueryPredicateArgs = {
   address: Scalars['String']['input'];
 };
-
 
 export type GQLQueryRegisterArgs = {
   id: Scalars['ID']['input'];
   register: Scalars['U32']['input'];
 };
 
-
 export type GQLQueryRelayedTransactionStatusArgs = {
   id: Scalars['RelayedTransactionId']['input'];
 };
-
 
 export type GQLQuerySearchArgs = {
   query: Scalars['String']['input'];
 };
 
-
 export type GQLQueryTransactionArgs = {
   id: Scalars['TransactionId']['input'];
 };
-
 
 export type GQLQueryTransactionsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1128,7 +1121,6 @@ export type GQLQueryTransactionsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
-
 export type GQLQueryTransactionsByBlockIdArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -1136,7 +1128,6 @@ export type GQLQueryTransactionsByBlockIdArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
 };
-
 
 export type GQLQueryTransactionsByOwnerArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1192,7 +1183,7 @@ export enum GQLReceiptType {
   Revert = 'REVERT',
   ScriptResult = 'SCRIPT_RESULT',
   Transfer = 'TRANSFER',
-  TransferOut = 'TRANSFER_OUT'
+  TransferOut = 'TRANSFER_OUT',
 }
 
 export type GQLRelayedTransactionFailed = {
@@ -1206,7 +1197,7 @@ export type GQLRelayedTransactionStatus = GQLRelayedTransactionFailed;
 export enum GQLReturnType {
   Return = 'RETURN',
   ReturnData = 'RETURN_DATA',
-  Revert = 'REVERT'
+  Revert = 'REVERT',
 }
 
 export type GQLRunResult = {
@@ -1220,7 +1211,7 @@ export enum GQLRunState {
   /** Stopped on a breakpoint */
   Breakpoint = 'BREAKPOINT',
   /** All breakpoints have been processed, and the program has terminated */
-  Completed = 'COMPLETED'
+  Completed = 'COMPLETED',
 }
 
 export type GQLScriptParameters = {
@@ -1231,7 +1222,7 @@ export type GQLScriptParameters = {
 };
 
 export enum GQLScriptParametersVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
 export type GQLSearchAccount = {
@@ -1309,11 +1300,9 @@ export type GQLSubscription = {
   submitAndAwait: GQLTransactionStatus;
 };
 
-
 export type GQLSubscriptionStatusChangeArgs = {
   id: Scalars['TransactionId']['input'];
 };
-
 
 export type GQLSubscriptionSubmitAndAwaitArgs = {
   tx: Scalars['HexString']['input'];
@@ -1404,7 +1393,11 @@ export type GQLTransactionGasCosts = {
   gasUsed?: Maybe<Scalars['U64']['output']>;
 };
 
-export type GQLTransactionStatus = GQLFailureStatus | GQLSqueezedOutStatus | GQLSubmittedStatus | GQLSuccessStatus;
+export type GQLTransactionStatus =
+  | GQLFailureStatus
+  | GQLSqueezedOutStatus
+  | GQLSubmittedStatus
+  | GQLSuccessStatus;
 
 export type GQLTxParameters = {
   __typename: 'TxParameters';
@@ -1418,10 +1411,12 @@ export type GQLTxParameters = {
 };
 
 export enum GQLTxParametersVersion {
-  V1 = 'V1'
+  V1 = 'V1',
 }
 
-export type GQLUpgradePurpose = GQLConsensusParametersPurpose | GQLStateTransitionPurpose;
+export type GQLUpgradePurpose =
+  | GQLConsensusParametersPurpose
+  | GQLStateTransitionPurpose;
 
 export type GQLUtxoItem = {
   __typename: 'UtxoItem';
@@ -1443,10 +1438,22 @@ export type GQLBalanceQueryVariables = Exact<{
   owner: Scalars['Address']['input'];
 }>;
 
+export type GQLBalanceQuery = {
+  __typename: 'Query';
+  balance: {
+    __typename: 'Balance';
+    amount: string;
+    assetId: string;
+    owner: string;
+  };
+};
 
-export type GQLBalanceQuery = { __typename: 'Query', balance: { __typename: 'Balance', amount: string, assetId: string, owner: string } };
-
-export type GQLBalanceItemFragment = { __typename: 'Balance', amount: string, assetId: string, owner: string };
+export type GQLBalanceItemFragment = {
+  __typename: 'Balance';
+  amount: string;
+  assetId: string;
+  owner: string;
+};
 
 export type GQLBalancesQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1456,10 +1463,329 @@ export type GQLBalancesQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
+export type GQLBalancesQuery = {
+  __typename: 'Query';
+  balances: {
+    __typename: 'BalanceConnection';
+    nodes: Array<{
+      __typename: 'Balance';
+      amount: string;
+      assetId: string;
+      owner: string;
+    }>;
+    pageInfo: {
+      __typename: 'PageInfo';
+      endCursor?: string | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: string | null;
+    };
+  };
+};
 
-export type GQLBalancesQuery = { __typename: 'Query', balances: { __typename: 'BalanceConnection', nodes: Array<{ __typename: 'Balance', amount: string, assetId: string, owner: string }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
-
-export type GQLBlockItemFragment = { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> };
+export type GQLBlockItemFragment = {
+  __typename: 'Block';
+  height: string;
+  id: string;
+  consensus:
+    | {
+        __typename: 'Genesis';
+        chainConfigHash: string;
+        coinsRoot: string;
+        contractsRoot: string;
+        messagesRoot: string;
+        transactionsRoot: string;
+      }
+    | { __typename: 'PoAConsensus'; signature: string };
+  header: {
+    __typename: 'Header';
+    applicationHash: string;
+    consensusParametersVersion: string;
+    daHeight: string;
+    eventInboxRoot: string;
+    height: string;
+    id: string;
+    messageOutboxRoot: string;
+    messageReceiptCount: string;
+    prevRoot: string;
+    stateTransitionBytecodeVersion: string;
+    time: string;
+    transactionsCount: string;
+    transactionsRoot: string;
+  };
+  transactions: Array<{
+    __typename: 'Transaction';
+    bytecodeRoot?: string | null;
+    bytecodeWitnessIndex?: string | null;
+    id: string;
+    inputAssetIds?: Array<string> | null;
+    inputContracts?: Array<string> | null;
+    isCreate: boolean;
+    isMint: boolean;
+    isScript: boolean;
+    isUpgrade: boolean;
+    isUpload: boolean;
+    maturity?: string | null;
+    mintAmount?: string | null;
+    mintAssetId?: string | null;
+    mintGasPrice?: string | null;
+    proofSet?: Array<string> | null;
+    rawPayload: string;
+    receiptsRoot?: string | null;
+    salt?: string | null;
+    script?: string | null;
+    scriptData?: string | null;
+    scriptGasLimit?: string | null;
+    storageSlots?: Array<string> | null;
+    subsectionIndex?: string | null;
+    subsectionsNumber?: string | null;
+    txPointer?: string | null;
+    witnesses?: Array<string> | null;
+    inputContract?: {
+      __typename: 'InputContract';
+      balanceRoot: string;
+      contractId: string;
+      stateRoot: string;
+      txPointer: string;
+      utxoId: string;
+    } | null;
+    inputs?: Array<
+      | {
+          __typename: 'InputCoin';
+          amount: string;
+          assetId: string;
+          owner: string;
+          predicate: string;
+          predicateData: string;
+          predicateGasUsed: string;
+          txPointer: string;
+          utxoId: string;
+          witnessIndex: string;
+        }
+      | {
+          __typename: 'InputContract';
+          balanceRoot: string;
+          contractId: string;
+          stateRoot: string;
+          txPointer: string;
+          utxoId: string;
+        }
+      | {
+          __typename: 'InputMessage';
+          amount: string;
+          data: string;
+          nonce: string;
+          predicate: string;
+          predicateData: string;
+          predicateGasUsed: string;
+          recipient: string;
+          sender: string;
+          witnessIndex: string;
+        }
+    > | null;
+    outputContract?: {
+      __typename: 'ContractOutput';
+      balanceRoot: string;
+      inputIndex: string;
+      stateRoot: string;
+    } | null;
+    outputs: Array<
+      | {
+          __typename: 'ChangeOutput';
+          amount: string;
+          assetId: string;
+          to: string;
+        }
+      | {
+          __typename: 'CoinOutput';
+          amount: string;
+          assetId: string;
+          to: string;
+        }
+      | { __typename: 'ContractCreated'; contract: string; stateRoot: string }
+      | {
+          __typename: 'ContractOutput';
+          balanceRoot: string;
+          inputIndex: string;
+          stateRoot: string;
+        }
+      | {
+          __typename: 'VariableOutput';
+          amount: string;
+          assetId: string;
+          to: string;
+        }
+    >;
+    policies?: {
+      __typename: 'Policies';
+      maturity?: string | null;
+      maxFee?: string | null;
+      tip?: string | null;
+      witnessLimit?: string | null;
+    } | null;
+    status?:
+      | {
+          __typename: 'FailureStatus';
+          reason: string;
+          time: string;
+          totalFee: string;
+          totalGas: string;
+          transactionId: string;
+          block: {
+            __typename: 'Block';
+            height: string;
+            id: string;
+            consensus:
+              | {
+                  __typename: 'Genesis';
+                  chainConfigHash: string;
+                  coinsRoot: string;
+                  contractsRoot: string;
+                  messagesRoot: string;
+                  transactionsRoot: string;
+                }
+              | { __typename: 'PoAConsensus'; signature: string };
+            header: {
+              __typename: 'Header';
+              applicationHash: string;
+              consensusParametersVersion: string;
+              daHeight: string;
+              eventInboxRoot: string;
+              height: string;
+              id: string;
+              messageOutboxRoot: string;
+              messageReceiptCount: string;
+              prevRoot: string;
+              stateTransitionBytecodeVersion: string;
+              time: string;
+              transactionsCount: string;
+              transactionsRoot: string;
+            };
+          };
+          programState?: {
+            __typename: 'ProgramState';
+            data: string;
+            returnType: GQLReturnType;
+          } | null;
+          receipts: Array<{
+            __typename: 'Receipt';
+            amount?: string | null;
+            assetId?: string | null;
+            contractId?: string | null;
+            data?: string | null;
+            digest?: string | null;
+            gas?: string | null;
+            gasUsed?: string | null;
+            id?: string | null;
+            is?: string | null;
+            len?: string | null;
+            nonce?: string | null;
+            param1?: string | null;
+            param2?: string | null;
+            pc?: string | null;
+            ptr?: string | null;
+            ra?: string | null;
+            rb?: string | null;
+            rc?: string | null;
+            rd?: string | null;
+            reason?: string | null;
+            receiptType: GQLReceiptType;
+            recipient?: string | null;
+            result?: string | null;
+            sender?: string | null;
+            subId?: string | null;
+            to?: string | null;
+            toAddress?: string | null;
+            val?: string | null;
+          }>;
+        }
+      | { __typename: 'SqueezedOutStatus'; reason: string }
+      | { __typename: 'SubmittedStatus'; time: string }
+      | {
+          __typename: 'SuccessStatus';
+          time: string;
+          totalFee: string;
+          totalGas: string;
+          transactionId: string;
+          block: {
+            __typename: 'Block';
+            height: string;
+            id: string;
+            consensus:
+              | {
+                  __typename: 'Genesis';
+                  chainConfigHash: string;
+                  coinsRoot: string;
+                  contractsRoot: string;
+                  messagesRoot: string;
+                  transactionsRoot: string;
+                }
+              | { __typename: 'PoAConsensus'; signature: string };
+            header: {
+              __typename: 'Header';
+              applicationHash: string;
+              consensusParametersVersion: string;
+              daHeight: string;
+              eventInboxRoot: string;
+              height: string;
+              id: string;
+              messageOutboxRoot: string;
+              messageReceiptCount: string;
+              prevRoot: string;
+              stateTransitionBytecodeVersion: string;
+              time: string;
+              transactionsCount: string;
+              transactionsRoot: string;
+            };
+          };
+          programState?: {
+            __typename: 'ProgramState';
+            data: string;
+            returnType: GQLReturnType;
+          } | null;
+          receipts: Array<{
+            __typename: 'Receipt';
+            amount?: string | null;
+            assetId?: string | null;
+            contractId?: string | null;
+            data?: string | null;
+            digest?: string | null;
+            gas?: string | null;
+            gasUsed?: string | null;
+            id?: string | null;
+            is?: string | null;
+            len?: string | null;
+            nonce?: string | null;
+            param1?: string | null;
+            param2?: string | null;
+            pc?: string | null;
+            ptr?: string | null;
+            ra?: string | null;
+            rb?: string | null;
+            rc?: string | null;
+            rd?: string | null;
+            reason?: string | null;
+            receiptType: GQLReceiptType;
+            recipient?: string | null;
+            result?: string | null;
+            sender?: string | null;
+            subId?: string | null;
+            to?: string | null;
+            toAddress?: string | null;
+            val?: string | null;
+          }>;
+        }
+      | null;
+    upgradePurpose?:
+      | {
+          __typename: 'ConsensusParametersPurpose';
+          checksum: string;
+          witnessIndex: string;
+        }
+      | { __typename: 'StateTransitionPurpose'; root: string }
+      | null;
+  }>;
+};
 
 export type GQLBlocksQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1468,13 +1794,1587 @@ export type GQLBlocksQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
+export type GQLBlocksQuery = {
+  __typename: 'Query';
+  blocks: {
+    __typename: 'BlockConnection';
+    edges: Array<{
+      __typename: 'BlockEdge';
+      cursor: string;
+      node: {
+        __typename: 'Block';
+        height: string;
+        id: string;
+        consensus:
+          | {
+              __typename: 'Genesis';
+              chainConfigHash: string;
+              coinsRoot: string;
+              contractsRoot: string;
+              messagesRoot: string;
+              transactionsRoot: string;
+            }
+          | { __typename: 'PoAConsensus'; signature: string };
+        header: {
+          __typename: 'Header';
+          applicationHash: string;
+          consensusParametersVersion: string;
+          daHeight: string;
+          eventInboxRoot: string;
+          height: string;
+          id: string;
+          messageOutboxRoot: string;
+          messageReceiptCount: string;
+          prevRoot: string;
+          stateTransitionBytecodeVersion: string;
+          time: string;
+          transactionsCount: string;
+          transactionsRoot: string;
+        };
+        transactions: Array<{
+          __typename: 'Transaction';
+          bytecodeRoot?: string | null;
+          bytecodeWitnessIndex?: string | null;
+          id: string;
+          inputAssetIds?: Array<string> | null;
+          inputContracts?: Array<string> | null;
+          isCreate: boolean;
+          isMint: boolean;
+          isScript: boolean;
+          isUpgrade: boolean;
+          isUpload: boolean;
+          maturity?: string | null;
+          mintAmount?: string | null;
+          mintAssetId?: string | null;
+          mintGasPrice?: string | null;
+          proofSet?: Array<string> | null;
+          rawPayload: string;
+          receiptsRoot?: string | null;
+          salt?: string | null;
+          script?: string | null;
+          scriptData?: string | null;
+          scriptGasLimit?: string | null;
+          storageSlots?: Array<string> | null;
+          subsectionIndex?: string | null;
+          subsectionsNumber?: string | null;
+          txPointer?: string | null;
+          witnesses?: Array<string> | null;
+          inputContract?: {
+            __typename: 'InputContract';
+            balanceRoot: string;
+            contractId: string;
+            stateRoot: string;
+            txPointer: string;
+            utxoId: string;
+          } | null;
+          inputs?: Array<
+            | {
+                __typename: 'InputCoin';
+                amount: string;
+                assetId: string;
+                owner: string;
+                predicate: string;
+                predicateData: string;
+                predicateGasUsed: string;
+                txPointer: string;
+                utxoId: string;
+                witnessIndex: string;
+              }
+            | {
+                __typename: 'InputContract';
+                balanceRoot: string;
+                contractId: string;
+                stateRoot: string;
+                txPointer: string;
+                utxoId: string;
+              }
+            | {
+                __typename: 'InputMessage';
+                amount: string;
+                data: string;
+                nonce: string;
+                predicate: string;
+                predicateData: string;
+                predicateGasUsed: string;
+                recipient: string;
+                sender: string;
+                witnessIndex: string;
+              }
+          > | null;
+          outputContract?: {
+            __typename: 'ContractOutput';
+            balanceRoot: string;
+            inputIndex: string;
+            stateRoot: string;
+          } | null;
+          outputs: Array<
+            | {
+                __typename: 'ChangeOutput';
+                amount: string;
+                assetId: string;
+                to: string;
+              }
+            | {
+                __typename: 'CoinOutput';
+                amount: string;
+                assetId: string;
+                to: string;
+              }
+            | {
+                __typename: 'ContractCreated';
+                contract: string;
+                stateRoot: string;
+              }
+            | {
+                __typename: 'ContractOutput';
+                balanceRoot: string;
+                inputIndex: string;
+                stateRoot: string;
+              }
+            | {
+                __typename: 'VariableOutput';
+                amount: string;
+                assetId: string;
+                to: string;
+              }
+          >;
+          policies?: {
+            __typename: 'Policies';
+            maturity?: string | null;
+            maxFee?: string | null;
+            tip?: string | null;
+            witnessLimit?: string | null;
+          } | null;
+          status?:
+            | {
+                __typename: 'FailureStatus';
+                reason: string;
+                time: string;
+                totalFee: string;
+                totalGas: string;
+                transactionId: string;
+                block: {
+                  __typename: 'Block';
+                  height: string;
+                  id: string;
+                  consensus:
+                    | {
+                        __typename: 'Genesis';
+                        chainConfigHash: string;
+                        coinsRoot: string;
+                        contractsRoot: string;
+                        messagesRoot: string;
+                        transactionsRoot: string;
+                      }
+                    | { __typename: 'PoAConsensus'; signature: string };
+                  header: {
+                    __typename: 'Header';
+                    applicationHash: string;
+                    consensusParametersVersion: string;
+                    daHeight: string;
+                    eventInboxRoot: string;
+                    height: string;
+                    id: string;
+                    messageOutboxRoot: string;
+                    messageReceiptCount: string;
+                    prevRoot: string;
+                    stateTransitionBytecodeVersion: string;
+                    time: string;
+                    transactionsCount: string;
+                    transactionsRoot: string;
+                  };
+                };
+                programState?: {
+                  __typename: 'ProgramState';
+                  data: string;
+                  returnType: GQLReturnType;
+                } | null;
+                receipts: Array<{
+                  __typename: 'Receipt';
+                  amount?: string | null;
+                  assetId?: string | null;
+                  contractId?: string | null;
+                  data?: string | null;
+                  digest?: string | null;
+                  gas?: string | null;
+                  gasUsed?: string | null;
+                  id?: string | null;
+                  is?: string | null;
+                  len?: string | null;
+                  nonce?: string | null;
+                  param1?: string | null;
+                  param2?: string | null;
+                  pc?: string | null;
+                  ptr?: string | null;
+                  ra?: string | null;
+                  rb?: string | null;
+                  rc?: string | null;
+                  rd?: string | null;
+                  reason?: string | null;
+                  receiptType: GQLReceiptType;
+                  recipient?: string | null;
+                  result?: string | null;
+                  sender?: string | null;
+                  subId?: string | null;
+                  to?: string | null;
+                  toAddress?: string | null;
+                  val?: string | null;
+                }>;
+              }
+            | { __typename: 'SqueezedOutStatus'; reason: string }
+            | { __typename: 'SubmittedStatus'; time: string }
+            | {
+                __typename: 'SuccessStatus';
+                time: string;
+                totalFee: string;
+                totalGas: string;
+                transactionId: string;
+                block: {
+                  __typename: 'Block';
+                  height: string;
+                  id: string;
+                  consensus:
+                    | {
+                        __typename: 'Genesis';
+                        chainConfigHash: string;
+                        coinsRoot: string;
+                        contractsRoot: string;
+                        messagesRoot: string;
+                        transactionsRoot: string;
+                      }
+                    | { __typename: 'PoAConsensus'; signature: string };
+                  header: {
+                    __typename: 'Header';
+                    applicationHash: string;
+                    consensusParametersVersion: string;
+                    daHeight: string;
+                    eventInboxRoot: string;
+                    height: string;
+                    id: string;
+                    messageOutboxRoot: string;
+                    messageReceiptCount: string;
+                    prevRoot: string;
+                    stateTransitionBytecodeVersion: string;
+                    time: string;
+                    transactionsCount: string;
+                    transactionsRoot: string;
+                  };
+                };
+                programState?: {
+                  __typename: 'ProgramState';
+                  data: string;
+                  returnType: GQLReturnType;
+                } | null;
+                receipts: Array<{
+                  __typename: 'Receipt';
+                  amount?: string | null;
+                  assetId?: string | null;
+                  contractId?: string | null;
+                  data?: string | null;
+                  digest?: string | null;
+                  gas?: string | null;
+                  gasUsed?: string | null;
+                  id?: string | null;
+                  is?: string | null;
+                  len?: string | null;
+                  nonce?: string | null;
+                  param1?: string | null;
+                  param2?: string | null;
+                  pc?: string | null;
+                  ptr?: string | null;
+                  ra?: string | null;
+                  rb?: string | null;
+                  rc?: string | null;
+                  rd?: string | null;
+                  reason?: string | null;
+                  receiptType: GQLReceiptType;
+                  recipient?: string | null;
+                  result?: string | null;
+                  sender?: string | null;
+                  subId?: string | null;
+                  to?: string | null;
+                  toAddress?: string | null;
+                  val?: string | null;
+                }>;
+              }
+            | null;
+          upgradePurpose?:
+            | {
+                __typename: 'ConsensusParametersPurpose';
+                checksum: string;
+                witnessIndex: string;
+              }
+            | { __typename: 'StateTransitionPurpose'; root: string }
+            | null;
+        }>;
+      };
+    }>;
+    nodes: Array<{
+      __typename: 'Block';
+      height: string;
+      id: string;
+      consensus:
+        | {
+            __typename: 'Genesis';
+            chainConfigHash: string;
+            coinsRoot: string;
+            contractsRoot: string;
+            messagesRoot: string;
+            transactionsRoot: string;
+          }
+        | { __typename: 'PoAConsensus'; signature: string };
+      header: {
+        __typename: 'Header';
+        applicationHash: string;
+        consensusParametersVersion: string;
+        daHeight: string;
+        eventInboxRoot: string;
+        height: string;
+        id: string;
+        messageOutboxRoot: string;
+        messageReceiptCount: string;
+        prevRoot: string;
+        stateTransitionBytecodeVersion: string;
+        time: string;
+        transactionsCount: string;
+        transactionsRoot: string;
+      };
+      transactions: Array<{
+        __typename: 'Transaction';
+        bytecodeRoot?: string | null;
+        bytecodeWitnessIndex?: string | null;
+        id: string;
+        inputAssetIds?: Array<string> | null;
+        inputContracts?: Array<string> | null;
+        isCreate: boolean;
+        isMint: boolean;
+        isScript: boolean;
+        isUpgrade: boolean;
+        isUpload: boolean;
+        maturity?: string | null;
+        mintAmount?: string | null;
+        mintAssetId?: string | null;
+        mintGasPrice?: string | null;
+        proofSet?: Array<string> | null;
+        rawPayload: string;
+        receiptsRoot?: string | null;
+        salt?: string | null;
+        script?: string | null;
+        scriptData?: string | null;
+        scriptGasLimit?: string | null;
+        storageSlots?: Array<string> | null;
+        subsectionIndex?: string | null;
+        subsectionsNumber?: string | null;
+        txPointer?: string | null;
+        witnesses?: Array<string> | null;
+        inputContract?: {
+          __typename: 'InputContract';
+          balanceRoot: string;
+          contractId: string;
+          stateRoot: string;
+          txPointer: string;
+          utxoId: string;
+        } | null;
+        inputs?: Array<
+          | {
+              __typename: 'InputCoin';
+              amount: string;
+              assetId: string;
+              owner: string;
+              predicate: string;
+              predicateData: string;
+              predicateGasUsed: string;
+              txPointer: string;
+              utxoId: string;
+              witnessIndex: string;
+            }
+          | {
+              __typename: 'InputContract';
+              balanceRoot: string;
+              contractId: string;
+              stateRoot: string;
+              txPointer: string;
+              utxoId: string;
+            }
+          | {
+              __typename: 'InputMessage';
+              amount: string;
+              data: string;
+              nonce: string;
+              predicate: string;
+              predicateData: string;
+              predicateGasUsed: string;
+              recipient: string;
+              sender: string;
+              witnessIndex: string;
+            }
+        > | null;
+        outputContract?: {
+          __typename: 'ContractOutput';
+          balanceRoot: string;
+          inputIndex: string;
+          stateRoot: string;
+        } | null;
+        outputs: Array<
+          | {
+              __typename: 'ChangeOutput';
+              amount: string;
+              assetId: string;
+              to: string;
+            }
+          | {
+              __typename: 'CoinOutput';
+              amount: string;
+              assetId: string;
+              to: string;
+            }
+          | {
+              __typename: 'ContractCreated';
+              contract: string;
+              stateRoot: string;
+            }
+          | {
+              __typename: 'ContractOutput';
+              balanceRoot: string;
+              inputIndex: string;
+              stateRoot: string;
+            }
+          | {
+              __typename: 'VariableOutput';
+              amount: string;
+              assetId: string;
+              to: string;
+            }
+        >;
+        policies?: {
+          __typename: 'Policies';
+          maturity?: string | null;
+          maxFee?: string | null;
+          tip?: string | null;
+          witnessLimit?: string | null;
+        } | null;
+        status?:
+          | {
+              __typename: 'FailureStatus';
+              reason: string;
+              time: string;
+              totalFee: string;
+              totalGas: string;
+              transactionId: string;
+              block: {
+                __typename: 'Block';
+                height: string;
+                id: string;
+                consensus:
+                  | {
+                      __typename: 'Genesis';
+                      chainConfigHash: string;
+                      coinsRoot: string;
+                      contractsRoot: string;
+                      messagesRoot: string;
+                      transactionsRoot: string;
+                    }
+                  | { __typename: 'PoAConsensus'; signature: string };
+                header: {
+                  __typename: 'Header';
+                  applicationHash: string;
+                  consensusParametersVersion: string;
+                  daHeight: string;
+                  eventInboxRoot: string;
+                  height: string;
+                  id: string;
+                  messageOutboxRoot: string;
+                  messageReceiptCount: string;
+                  prevRoot: string;
+                  stateTransitionBytecodeVersion: string;
+                  time: string;
+                  transactionsCount: string;
+                  transactionsRoot: string;
+                };
+              };
+              programState?: {
+                __typename: 'ProgramState';
+                data: string;
+                returnType: GQLReturnType;
+              } | null;
+              receipts: Array<{
+                __typename: 'Receipt';
+                amount?: string | null;
+                assetId?: string | null;
+                contractId?: string | null;
+                data?: string | null;
+                digest?: string | null;
+                gas?: string | null;
+                gasUsed?: string | null;
+                id?: string | null;
+                is?: string | null;
+                len?: string | null;
+                nonce?: string | null;
+                param1?: string | null;
+                param2?: string | null;
+                pc?: string | null;
+                ptr?: string | null;
+                ra?: string | null;
+                rb?: string | null;
+                rc?: string | null;
+                rd?: string | null;
+                reason?: string | null;
+                receiptType: GQLReceiptType;
+                recipient?: string | null;
+                result?: string | null;
+                sender?: string | null;
+                subId?: string | null;
+                to?: string | null;
+                toAddress?: string | null;
+                val?: string | null;
+              }>;
+            }
+          | { __typename: 'SqueezedOutStatus'; reason: string }
+          | { __typename: 'SubmittedStatus'; time: string }
+          | {
+              __typename: 'SuccessStatus';
+              time: string;
+              totalFee: string;
+              totalGas: string;
+              transactionId: string;
+              block: {
+                __typename: 'Block';
+                height: string;
+                id: string;
+                consensus:
+                  | {
+                      __typename: 'Genesis';
+                      chainConfigHash: string;
+                      coinsRoot: string;
+                      contractsRoot: string;
+                      messagesRoot: string;
+                      transactionsRoot: string;
+                    }
+                  | { __typename: 'PoAConsensus'; signature: string };
+                header: {
+                  __typename: 'Header';
+                  applicationHash: string;
+                  consensusParametersVersion: string;
+                  daHeight: string;
+                  eventInboxRoot: string;
+                  height: string;
+                  id: string;
+                  messageOutboxRoot: string;
+                  messageReceiptCount: string;
+                  prevRoot: string;
+                  stateTransitionBytecodeVersion: string;
+                  time: string;
+                  transactionsCount: string;
+                  transactionsRoot: string;
+                };
+              };
+              programState?: {
+                __typename: 'ProgramState';
+                data: string;
+                returnType: GQLReturnType;
+              } | null;
+              receipts: Array<{
+                __typename: 'Receipt';
+                amount?: string | null;
+                assetId?: string | null;
+                contractId?: string | null;
+                data?: string | null;
+                digest?: string | null;
+                gas?: string | null;
+                gasUsed?: string | null;
+                id?: string | null;
+                is?: string | null;
+                len?: string | null;
+                nonce?: string | null;
+                param1?: string | null;
+                param2?: string | null;
+                pc?: string | null;
+                ptr?: string | null;
+                ra?: string | null;
+                rb?: string | null;
+                rc?: string | null;
+                rd?: string | null;
+                reason?: string | null;
+                receiptType: GQLReceiptType;
+                recipient?: string | null;
+                result?: string | null;
+                sender?: string | null;
+                subId?: string | null;
+                to?: string | null;
+                toAddress?: string | null;
+                val?: string | null;
+              }>;
+            }
+          | null;
+        upgradePurpose?:
+          | {
+              __typename: 'ConsensusParametersPurpose';
+              checksum: string;
+              witnessIndex: string;
+            }
+          | { __typename: 'StateTransitionPurpose'; root: string }
+          | null;
+      }>;
+    }>;
+    pageInfo: {
+      __typename: 'PageInfo';
+      endCursor?: string | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: string | null;
+    };
+  };
+};
 
-export type GQLBlocksQuery = { __typename: 'Query', blocks: { __typename: 'BlockConnection', edges: Array<{ __typename: 'BlockEdge', cursor: string, node: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> } }>, nodes: Array<{ __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+export type GQLChainQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GQLChainQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GQLChainQuery = { __typename: 'Query', chain: { __typename: 'ChainInfo', daHeight: string, name: string, consensusParameters: { __typename: 'ConsensusParameters', baseAssetId: string, blockGasLimit: string, chainId: string, privilegedAddress: string, contractParams: { __typename: 'ContractParameters', contractMaxSize: string, maxStorageSlots: string }, feeParams: { __typename: 'FeeParameters', gasPerByte: string, gasPriceFactor: string }, gasCosts: { __typename: 'GasCosts', add: string, addi: string, aloc: string, and: string, andi: string, bal: string, bhei: string, bhsh: string, burn: string, cb: string, cfei: string, cfsi: string, div: string, divi: string, eck1: string, ecr1: string, ed19: string, eq: string, exp: string, expi: string, flag: string, gm: string, gt: string, gtf: string, ji: string, jmp: string, jmpb: string, jmpf: string, jne: string, jneb: string, jnef: string, jnei: string, jnzb: string, jnzf: string, jnzi: string, lb: string, log: string, lt: string, lw: string, mint: string, mldv: string, mlog: string, modOp: string, modi: string, moveOp: string, movi: string, mroo: string, mul: string, muli: string, newStoragePerByte: string, noop: string, not: string, or: string, ori: string, poph: string, popl: string, pshh: string, pshl: string, ret: string, rvrt: string, sb: string, sll: string, slli: string, srl: string, srli: string, srw: string, sub: string, subi: string, sw: string, sww: string, time: string, tr: string, tro: string, wdam: string, wdcm: string, wddv: string, wdmd: string, wdml: string, wdmm: string, wdop: string, wqam: string, wqcm: string, wqdv: string, wqmd: string, wqml: string, wqmm: string, wqop: string, xor: string, xori: string, call: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ccp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, contractRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, croo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, csiz: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, k256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ldc: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, logd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcl: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcli: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcpi: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, meq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, retd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, s256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, scwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, smo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, srwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, stateRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, swwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, vmInitialization: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string } }, predicateParams: { __typename: 'PredicateParameters', maxGasPerPredicate: string, maxMessageDataLength: string, maxPredicateDataLength: string, maxPredicateLength: string }, scriptParams: { __typename: 'ScriptParameters', maxScriptDataLength: string, maxScriptLength: string }, txParams: { __typename: 'TxParameters', maxBytecodeSubsections: string, maxGasPerTx: string, maxInputs: string, maxOutputs: string, maxSize: string, maxWitnesses: string } }, gasCosts: { __typename: 'GasCosts', add: string, addi: string, aloc: string, and: string, andi: string, bal: string, bhei: string, bhsh: string, burn: string, cb: string, cfei: string, cfsi: string, div: string, divi: string, eck1: string, ecr1: string, ed19: string, eq: string, exp: string, expi: string, flag: string, gm: string, gt: string, gtf: string, ji: string, jmp: string, jmpb: string, jmpf: string, jne: string, jneb: string, jnef: string, jnei: string, jnzb: string, jnzf: string, jnzi: string, lb: string, log: string, lt: string, lw: string, mint: string, mldv: string, mlog: string, modOp: string, modi: string, moveOp: string, movi: string, mroo: string, mul: string, muli: string, newStoragePerByte: string, noop: string, not: string, or: string, ori: string, poph: string, popl: string, pshh: string, pshl: string, ret: string, rvrt: string, sb: string, sll: string, slli: string, srl: string, srli: string, srw: string, sub: string, subi: string, sw: string, sww: string, time: string, tr: string, tro: string, wdam: string, wdcm: string, wddv: string, wdmd: string, wdml: string, wdmm: string, wdop: string, wqam: string, wqcm: string, wqdv: string, wqmd: string, wqml: string, wqmm: string, wqop: string, xor: string, xori: string, call: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ccp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, contractRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, croo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, csiz: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, k256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ldc: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, logd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcl: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcli: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcpi: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, meq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, retd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, s256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, scwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, smo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, srwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, stateRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, swwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, vmInitialization: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string } }, latestBlock: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> } } };
+export type GQLChainQuery = {
+  __typename: 'Query';
+  chain: {
+    __typename: 'ChainInfo';
+    daHeight: string;
+    name: string;
+    consensusParameters: {
+      __typename: 'ConsensusParameters';
+      baseAssetId: string;
+      blockGasLimit: string;
+      chainId: string;
+      privilegedAddress: string;
+      contractParams: {
+        __typename: 'ContractParameters';
+        contractMaxSize: string;
+        maxStorageSlots: string;
+      };
+      feeParams: {
+        __typename: 'FeeParameters';
+        gasPerByte: string;
+        gasPriceFactor: string;
+      };
+      gasCosts: {
+        __typename: 'GasCosts';
+        add: string;
+        addi: string;
+        aloc: string;
+        and: string;
+        andi: string;
+        bal: string;
+        bhei: string;
+        bhsh: string;
+        burn: string;
+        cb: string;
+        cfei: string;
+        cfsi: string;
+        div: string;
+        divi: string;
+        eck1: string;
+        ecr1: string;
+        ed19: string;
+        eq: string;
+        exp: string;
+        expi: string;
+        flag: string;
+        gm: string;
+        gt: string;
+        gtf: string;
+        ji: string;
+        jmp: string;
+        jmpb: string;
+        jmpf: string;
+        jne: string;
+        jneb: string;
+        jnef: string;
+        jnei: string;
+        jnzb: string;
+        jnzf: string;
+        jnzi: string;
+        lb: string;
+        log: string;
+        lt: string;
+        lw: string;
+        mint: string;
+        mldv: string;
+        mlog: string;
+        modOp: string;
+        modi: string;
+        moveOp: string;
+        movi: string;
+        mroo: string;
+        mul: string;
+        muli: string;
+        newStoragePerByte: string;
+        noop: string;
+        not: string;
+        or: string;
+        ori: string;
+        poph: string;
+        popl: string;
+        pshh: string;
+        pshl: string;
+        ret: string;
+        rvrt: string;
+        sb: string;
+        sll: string;
+        slli: string;
+        srl: string;
+        srli: string;
+        srw: string;
+        sub: string;
+        subi: string;
+        sw: string;
+        sww: string;
+        time: string;
+        tr: string;
+        tro: string;
+        wdam: string;
+        wdcm: string;
+        wddv: string;
+        wdmd: string;
+        wdml: string;
+        wdmm: string;
+        wdop: string;
+        wqam: string;
+        wqcm: string;
+        wqdv: string;
+        wqmd: string;
+        wqml: string;
+        wqmm: string;
+        wqop: string;
+        xor: string;
+        xori: string;
+        call:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        ccp:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        contractRoot:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        croo:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        csiz:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        k256:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        ldc:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        logd:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        mcl:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        mcli:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        mcp:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        mcpi:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        meq:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        retd:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        s256:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        scwq:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        smo:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        srwq:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        stateRoot:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        swwq:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+        vmInitialization:
+          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      };
+      predicateParams: {
+        __typename: 'PredicateParameters';
+        maxGasPerPredicate: string;
+        maxMessageDataLength: string;
+        maxPredicateDataLength: string;
+        maxPredicateLength: string;
+      };
+      scriptParams: {
+        __typename: 'ScriptParameters';
+        maxScriptDataLength: string;
+        maxScriptLength: string;
+      };
+      txParams: {
+        __typename: 'TxParameters';
+        maxBytecodeSubsections: string;
+        maxGasPerTx: string;
+        maxInputs: string;
+        maxOutputs: string;
+        maxSize: string;
+        maxWitnesses: string;
+      };
+    };
+    gasCosts: {
+      __typename: 'GasCosts';
+      add: string;
+      addi: string;
+      aloc: string;
+      and: string;
+      andi: string;
+      bal: string;
+      bhei: string;
+      bhsh: string;
+      burn: string;
+      cb: string;
+      cfei: string;
+      cfsi: string;
+      div: string;
+      divi: string;
+      eck1: string;
+      ecr1: string;
+      ed19: string;
+      eq: string;
+      exp: string;
+      expi: string;
+      flag: string;
+      gm: string;
+      gt: string;
+      gtf: string;
+      ji: string;
+      jmp: string;
+      jmpb: string;
+      jmpf: string;
+      jne: string;
+      jneb: string;
+      jnef: string;
+      jnei: string;
+      jnzb: string;
+      jnzf: string;
+      jnzi: string;
+      lb: string;
+      log: string;
+      lt: string;
+      lw: string;
+      mint: string;
+      mldv: string;
+      mlog: string;
+      modOp: string;
+      modi: string;
+      moveOp: string;
+      movi: string;
+      mroo: string;
+      mul: string;
+      muli: string;
+      newStoragePerByte: string;
+      noop: string;
+      not: string;
+      or: string;
+      ori: string;
+      poph: string;
+      popl: string;
+      pshh: string;
+      pshl: string;
+      ret: string;
+      rvrt: string;
+      sb: string;
+      sll: string;
+      slli: string;
+      srl: string;
+      srli: string;
+      srw: string;
+      sub: string;
+      subi: string;
+      sw: string;
+      sww: string;
+      time: string;
+      tr: string;
+      tro: string;
+      wdam: string;
+      wdcm: string;
+      wddv: string;
+      wdmd: string;
+      wdml: string;
+      wdmm: string;
+      wdop: string;
+      wqam: string;
+      wqcm: string;
+      wqdv: string;
+      wqmd: string;
+      wqml: string;
+      wqmm: string;
+      wqop: string;
+      xor: string;
+      xori: string;
+      call:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      ccp:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      contractRoot:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      croo:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      csiz:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      k256:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      ldc:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      logd:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      mcl:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      mcli:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      mcp:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      mcpi:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      meq:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      retd:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      s256:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      scwq:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      smo:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      srwq:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      stateRoot:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      swwq:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+      vmInitialization:
+        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
+        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
+    };
+    latestBlock: {
+      __typename: 'Block';
+      height: string;
+      id: string;
+      consensus:
+        | {
+            __typename: 'Genesis';
+            chainConfigHash: string;
+            coinsRoot: string;
+            contractsRoot: string;
+            messagesRoot: string;
+            transactionsRoot: string;
+          }
+        | { __typename: 'PoAConsensus'; signature: string };
+      header: {
+        __typename: 'Header';
+        applicationHash: string;
+        consensusParametersVersion: string;
+        daHeight: string;
+        eventInboxRoot: string;
+        height: string;
+        id: string;
+        messageOutboxRoot: string;
+        messageReceiptCount: string;
+        prevRoot: string;
+        stateTransitionBytecodeVersion: string;
+        time: string;
+        transactionsCount: string;
+        transactionsRoot: string;
+      };
+      transactions: Array<{
+        __typename: 'Transaction';
+        bytecodeRoot?: string | null;
+        bytecodeWitnessIndex?: string | null;
+        id: string;
+        inputAssetIds?: Array<string> | null;
+        inputContracts?: Array<string> | null;
+        isCreate: boolean;
+        isMint: boolean;
+        isScript: boolean;
+        isUpgrade: boolean;
+        isUpload: boolean;
+        maturity?: string | null;
+        mintAmount?: string | null;
+        mintAssetId?: string | null;
+        mintGasPrice?: string | null;
+        proofSet?: Array<string> | null;
+        rawPayload: string;
+        receiptsRoot?: string | null;
+        salt?: string | null;
+        script?: string | null;
+        scriptData?: string | null;
+        scriptGasLimit?: string | null;
+        storageSlots?: Array<string> | null;
+        subsectionIndex?: string | null;
+        subsectionsNumber?: string | null;
+        txPointer?: string | null;
+        witnesses?: Array<string> | null;
+        inputContract?: {
+          __typename: 'InputContract';
+          balanceRoot: string;
+          contractId: string;
+          stateRoot: string;
+          txPointer: string;
+          utxoId: string;
+        } | null;
+        inputs?: Array<
+          | {
+              __typename: 'InputCoin';
+              amount: string;
+              assetId: string;
+              owner: string;
+              predicate: string;
+              predicateData: string;
+              predicateGasUsed: string;
+              txPointer: string;
+              utxoId: string;
+              witnessIndex: string;
+            }
+          | {
+              __typename: 'InputContract';
+              balanceRoot: string;
+              contractId: string;
+              stateRoot: string;
+              txPointer: string;
+              utxoId: string;
+            }
+          | {
+              __typename: 'InputMessage';
+              amount: string;
+              data: string;
+              nonce: string;
+              predicate: string;
+              predicateData: string;
+              predicateGasUsed: string;
+              recipient: string;
+              sender: string;
+              witnessIndex: string;
+            }
+        > | null;
+        outputContract?: {
+          __typename: 'ContractOutput';
+          balanceRoot: string;
+          inputIndex: string;
+          stateRoot: string;
+        } | null;
+        outputs: Array<
+          | {
+              __typename: 'ChangeOutput';
+              amount: string;
+              assetId: string;
+              to: string;
+            }
+          | {
+              __typename: 'CoinOutput';
+              amount: string;
+              assetId: string;
+              to: string;
+            }
+          | {
+              __typename: 'ContractCreated';
+              contract: string;
+              stateRoot: string;
+            }
+          | {
+              __typename: 'ContractOutput';
+              balanceRoot: string;
+              inputIndex: string;
+              stateRoot: string;
+            }
+          | {
+              __typename: 'VariableOutput';
+              amount: string;
+              assetId: string;
+              to: string;
+            }
+        >;
+        policies?: {
+          __typename: 'Policies';
+          maturity?: string | null;
+          maxFee?: string | null;
+          tip?: string | null;
+          witnessLimit?: string | null;
+        } | null;
+        status?:
+          | {
+              __typename: 'FailureStatus';
+              reason: string;
+              time: string;
+              totalFee: string;
+              totalGas: string;
+              transactionId: string;
+              block: {
+                __typename: 'Block';
+                height: string;
+                id: string;
+                consensus:
+                  | {
+                      __typename: 'Genesis';
+                      chainConfigHash: string;
+                      coinsRoot: string;
+                      contractsRoot: string;
+                      messagesRoot: string;
+                      transactionsRoot: string;
+                    }
+                  | { __typename: 'PoAConsensus'; signature: string };
+                header: {
+                  __typename: 'Header';
+                  applicationHash: string;
+                  consensusParametersVersion: string;
+                  daHeight: string;
+                  eventInboxRoot: string;
+                  height: string;
+                  id: string;
+                  messageOutboxRoot: string;
+                  messageReceiptCount: string;
+                  prevRoot: string;
+                  stateTransitionBytecodeVersion: string;
+                  time: string;
+                  transactionsCount: string;
+                  transactionsRoot: string;
+                };
+                transactions: Array<{
+                  __typename: 'Transaction';
+                  bytecodeRoot?: string | null;
+                  bytecodeWitnessIndex?: string | null;
+                  id: string;
+                  inputAssetIds?: Array<string> | null;
+                  inputContracts?: Array<string> | null;
+                  isCreate: boolean;
+                  isMint: boolean;
+                  isScript: boolean;
+                  isUpgrade: boolean;
+                  isUpload: boolean;
+                  maturity?: string | null;
+                  mintAmount?: string | null;
+                  mintAssetId?: string | null;
+                  mintGasPrice?: string | null;
+                  proofSet?: Array<string> | null;
+                  rawPayload: string;
+                  receiptsRoot?: string | null;
+                  salt?: string | null;
+                  script?: string | null;
+                  scriptData?: string | null;
+                  scriptGasLimit?: string | null;
+                  storageSlots?: Array<string> | null;
+                  subsectionIndex?: string | null;
+                  subsectionsNumber?: string | null;
+                  txPointer?: string | null;
+                  witnesses?: Array<string> | null;
+                  inputContract?: {
+                    __typename: 'InputContract';
+                    balanceRoot: string;
+                    contractId: string;
+                    stateRoot: string;
+                    txPointer: string;
+                    utxoId: string;
+                  } | null;
+                  inputs?: Array<
+                    | {
+                        __typename: 'InputCoin';
+                        amount: string;
+                        assetId: string;
+                        owner: string;
+                        predicate: string;
+                        predicateData: string;
+                        predicateGasUsed: string;
+                        txPointer: string;
+                        utxoId: string;
+                        witnessIndex: string;
+                      }
+                    | {
+                        __typename: 'InputContract';
+                        balanceRoot: string;
+                        contractId: string;
+                        stateRoot: string;
+                        txPointer: string;
+                        utxoId: string;
+                      }
+                    | {
+                        __typename: 'InputMessage';
+                        amount: string;
+                        data: string;
+                        nonce: string;
+                        predicate: string;
+                        predicateData: string;
+                        predicateGasUsed: string;
+                        recipient: string;
+                        sender: string;
+                        witnessIndex: string;
+                      }
+                  > | null;
+                  outputContract?: {
+                    __typename: 'ContractOutput';
+                    balanceRoot: string;
+                    inputIndex: string;
+                    stateRoot: string;
+                  } | null;
+                  outputs: Array<
+                    | {
+                        __typename: 'ChangeOutput';
+                        amount: string;
+                        assetId: string;
+                        to: string;
+                      }
+                    | {
+                        __typename: 'CoinOutput';
+                        amount: string;
+                        assetId: string;
+                        to: string;
+                      }
+                    | {
+                        __typename: 'ContractCreated';
+                        contract: string;
+                        stateRoot: string;
+                      }
+                    | {
+                        __typename: 'ContractOutput';
+                        balanceRoot: string;
+                        inputIndex: string;
+                        stateRoot: string;
+                      }
+                    | {
+                        __typename: 'VariableOutput';
+                        amount: string;
+                        assetId: string;
+                        to: string;
+                      }
+                  >;
+                  policies?: {
+                    __typename: 'Policies';
+                    maturity?: string | null;
+                    maxFee?: string | null;
+                    tip?: string | null;
+                    witnessLimit?: string | null;
+                  } | null;
+                  status?:
+                    | {
+                        __typename: 'FailureStatus';
+                        reason: string;
+                        time: string;
+                        totalFee: string;
+                        totalGas: string;
+                        transactionId: string;
+                      }
+                    | { __typename: 'SqueezedOutStatus'; reason: string }
+                    | { __typename: 'SubmittedStatus'; time: string }
+                    | {
+                        __typename: 'SuccessStatus';
+                        time: string;
+                        totalFee: string;
+                        totalGas: string;
+                        transactionId: string;
+                      }
+                    | null;
+                  upgradePurpose?:
+                    | {
+                        __typename: 'ConsensusParametersPurpose';
+                        checksum: string;
+                        witnessIndex: string;
+                      }
+                    | { __typename: 'StateTransitionPurpose'; root: string }
+                    | null;
+                }>;
+              };
+              programState?: {
+                __typename: 'ProgramState';
+                data: string;
+                returnType: GQLReturnType;
+              } | null;
+              receipts: Array<{
+                __typename: 'Receipt';
+                amount?: string | null;
+                assetId?: string | null;
+                contractId?: string | null;
+                data?: string | null;
+                digest?: string | null;
+                gas?: string | null;
+                gasUsed?: string | null;
+                id?: string | null;
+                is?: string | null;
+                len?: string | null;
+                nonce?: string | null;
+                param1?: string | null;
+                param2?: string | null;
+                pc?: string | null;
+                ptr?: string | null;
+                ra?: string | null;
+                rb?: string | null;
+                rc?: string | null;
+                rd?: string | null;
+                reason?: string | null;
+                receiptType: GQLReceiptType;
+                recipient?: string | null;
+                result?: string | null;
+                sender?: string | null;
+                subId?: string | null;
+                to?: string | null;
+                toAddress?: string | null;
+                val?: string | null;
+              }>;
+            }
+          | { __typename: 'SqueezedOutStatus'; reason: string }
+          | { __typename: 'SubmittedStatus'; time: string }
+          | {
+              __typename: 'SuccessStatus';
+              time: string;
+              totalFee: string;
+              totalGas: string;
+              transactionId: string;
+              block: {
+                __typename: 'Block';
+                height: string;
+                id: string;
+                consensus:
+                  | {
+                      __typename: 'Genesis';
+                      chainConfigHash: string;
+                      coinsRoot: string;
+                      contractsRoot: string;
+                      messagesRoot: string;
+                      transactionsRoot: string;
+                    }
+                  | { __typename: 'PoAConsensus'; signature: string };
+                header: {
+                  __typename: 'Header';
+                  applicationHash: string;
+                  consensusParametersVersion: string;
+                  daHeight: string;
+                  eventInboxRoot: string;
+                  height: string;
+                  id: string;
+                  messageOutboxRoot: string;
+                  messageReceiptCount: string;
+                  prevRoot: string;
+                  stateTransitionBytecodeVersion: string;
+                  time: string;
+                  transactionsCount: string;
+                  transactionsRoot: string;
+                };
+                transactions: Array<{
+                  __typename: 'Transaction';
+                  bytecodeRoot?: string | null;
+                  bytecodeWitnessIndex?: string | null;
+                  id: string;
+                  inputAssetIds?: Array<string> | null;
+                  inputContracts?: Array<string> | null;
+                  isCreate: boolean;
+                  isMint: boolean;
+                  isScript: boolean;
+                  isUpgrade: boolean;
+                  isUpload: boolean;
+                  maturity?: string | null;
+                  mintAmount?: string | null;
+                  mintAssetId?: string | null;
+                  mintGasPrice?: string | null;
+                  proofSet?: Array<string> | null;
+                  rawPayload: string;
+                  receiptsRoot?: string | null;
+                  salt?: string | null;
+                  script?: string | null;
+                  scriptData?: string | null;
+                  scriptGasLimit?: string | null;
+                  storageSlots?: Array<string> | null;
+                  subsectionIndex?: string | null;
+                  subsectionsNumber?: string | null;
+                  txPointer?: string | null;
+                  witnesses?: Array<string> | null;
+                  inputContract?: {
+                    __typename: 'InputContract';
+                    balanceRoot: string;
+                    contractId: string;
+                    stateRoot: string;
+                    txPointer: string;
+                    utxoId: string;
+                  } | null;
+                  inputs?: Array<
+                    | {
+                        __typename: 'InputCoin';
+                        amount: string;
+                        assetId: string;
+                        owner: string;
+                        predicate: string;
+                        predicateData: string;
+                        predicateGasUsed: string;
+                        txPointer: string;
+                        utxoId: string;
+                        witnessIndex: string;
+                      }
+                    | {
+                        __typename: 'InputContract';
+                        balanceRoot: string;
+                        contractId: string;
+                        stateRoot: string;
+                        txPointer: string;
+                        utxoId: string;
+                      }
+                    | {
+                        __typename: 'InputMessage';
+                        amount: string;
+                        data: string;
+                        nonce: string;
+                        predicate: string;
+                        predicateData: string;
+                        predicateGasUsed: string;
+                        recipient: string;
+                        sender: string;
+                        witnessIndex: string;
+                      }
+                  > | null;
+                  outputContract?: {
+                    __typename: 'ContractOutput';
+                    balanceRoot: string;
+                    inputIndex: string;
+                    stateRoot: string;
+                  } | null;
+                  outputs: Array<
+                    | {
+                        __typename: 'ChangeOutput';
+                        amount: string;
+                        assetId: string;
+                        to: string;
+                      }
+                    | {
+                        __typename: 'CoinOutput';
+                        amount: string;
+                        assetId: string;
+                        to: string;
+                      }
+                    | {
+                        __typename: 'ContractCreated';
+                        contract: string;
+                        stateRoot: string;
+                      }
+                    | {
+                        __typename: 'ContractOutput';
+                        balanceRoot: string;
+                        inputIndex: string;
+                        stateRoot: string;
+                      }
+                    | {
+                        __typename: 'VariableOutput';
+                        amount: string;
+                        assetId: string;
+                        to: string;
+                      }
+                  >;
+                  policies?: {
+                    __typename: 'Policies';
+                    maturity?: string | null;
+                    maxFee?: string | null;
+                    tip?: string | null;
+                    witnessLimit?: string | null;
+                  } | null;
+                  status?:
+                    | {
+                        __typename: 'FailureStatus';
+                        reason: string;
+                        time: string;
+                        totalFee: string;
+                        totalGas: string;
+                        transactionId: string;
+                      }
+                    | { __typename: 'SqueezedOutStatus'; reason: string }
+                    | { __typename: 'SubmittedStatus'; time: string }
+                    | {
+                        __typename: 'SuccessStatus';
+                        time: string;
+                        totalFee: string;
+                        totalGas: string;
+                        transactionId: string;
+                      }
+                    | null;
+                  upgradePurpose?:
+                    | {
+                        __typename: 'ConsensusParametersPurpose';
+                        checksum: string;
+                        witnessIndex: string;
+                      }
+                    | { __typename: 'StateTransitionPurpose'; root: string }
+                    | null;
+                }>;
+              };
+              programState?: {
+                __typename: 'ProgramState';
+                data: string;
+                returnType: GQLReturnType;
+              } | null;
+              receipts: Array<{
+                __typename: 'Receipt';
+                amount?: string | null;
+                assetId?: string | null;
+                contractId?: string | null;
+                data?: string | null;
+                digest?: string | null;
+                gas?: string | null;
+                gasUsed?: string | null;
+                id?: string | null;
+                is?: string | null;
+                len?: string | null;
+                nonce?: string | null;
+                param1?: string | null;
+                param2?: string | null;
+                pc?: string | null;
+                ptr?: string | null;
+                ra?: string | null;
+                rb?: string | null;
+                rc?: string | null;
+                rd?: string | null;
+                reason?: string | null;
+                receiptType: GQLReceiptType;
+                recipient?: string | null;
+                result?: string | null;
+                sender?: string | null;
+                subId?: string | null;
+                to?: string | null;
+                toAddress?: string | null;
+                val?: string | null;
+              }>;
+            }
+          | null;
+        upgradePurpose?:
+          | {
+              __typename: 'ConsensusParametersPurpose';
+              checksum: string;
+              witnessIndex: string;
+            }
+          | { __typename: 'StateTransitionPurpose'; root: string }
+          | null;
+      }>;
+    };
+  };
+};
 
 export type GQLCoinsQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1484,27 +3384,87 @@ export type GQLCoinsQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-
-export type GQLCoinsQuery = { __typename: 'Query', coins: { __typename: 'CoinConnection', edges: Array<{ __typename: 'CoinEdge', cursor: string, node: { __typename: 'Coin', amount: string, assetId: string, blockCreated: string, owner: string, txCreatedIdx: string, utxoId: string } }>, nodes: Array<{ __typename: 'Coin', amount: string, assetId: string, blockCreated: string, owner: string, txCreatedIdx: string, utxoId: string }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+export type GQLCoinsQuery = {
+  __typename: 'Query';
+  coins: {
+    __typename: 'CoinConnection';
+    edges: Array<{
+      __typename: 'CoinEdge';
+      cursor: string;
+      node: {
+        __typename: 'Coin';
+        amount: string;
+        assetId: string;
+        blockCreated: string;
+        owner: string;
+        txCreatedIdx: string;
+        utxoId: string;
+      };
+    }>;
+    nodes: Array<{
+      __typename: 'Coin';
+      amount: string;
+      assetId: string;
+      blockCreated: string;
+      owner: string;
+      txCreatedIdx: string;
+      utxoId: string;
+    }>;
+    pageInfo: {
+      __typename: 'PageInfo';
+      endCursor?: string | null;
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      startCursor?: string | null;
+    };
+  };
+};
 
 export type GQLContractQueryVariables = Exact<{
   id: Scalars['ContractId']['input'];
 }>;
 
-
-export type GQLContractQuery = { __typename: 'Query', contract?: { __typename: 'Contract', id: string, bytecode: string } | null };
+export type GQLContractQuery = {
+  __typename: 'Query';
+  contract?: { __typename: 'Contract'; id: string; bytecode: string } | null;
+};
 
 export type GQLContractBalanceQueryVariables = Exact<{
   asset: Scalars['AssetId']['input'];
   contract: Scalars['ContractId']['input'];
 }>;
 
+export type GQLContractBalanceQuery = {
+  __typename: 'Query';
+  contractBalance: {
+    __typename: 'ContractBalance';
+    amount: string;
+    assetId: string;
+    contract: string;
+  };
+};
 
-export type GQLContractBalanceQuery = { __typename: 'Query', contractBalance: { __typename: 'ContractBalance', amount: string, assetId: string, contract: string } };
+export type GQLContractBalanceNodeFragment = {
+  __typename: 'ContractBalance';
+  amount: string;
+  assetId: string;
+};
 
-export type GQLContractBalanceNodeFragment = { __typename: 'ContractBalance', amount: string, assetId: string };
-
-export type GQLContractBalanceConnectionNodeFragment = { __typename: 'ContractBalanceConnection', edges: Array<{ __typename: 'ContractBalanceEdge', cursor: string, node: { __typename: 'ContractBalance', amount: string, assetId: string } }>, pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null, startCursor?: string | null } };
+export type GQLContractBalanceConnectionNodeFragment = {
+  __typename: 'ContractBalanceConnection';
+  edges: Array<{
+    __typename: 'ContractBalanceEdge';
+    cursor: string;
+    node: { __typename: 'ContractBalance'; amount: string; assetId: string };
+  }>;
+  pageInfo: {
+    __typename: 'PageInfo';
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+    endCursor?: string | null;
+    startCursor?: string | null;
+  };
+};
 
 export type GQLContractBalancesQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1514,13 +3474,47 @@ export type GQLContractBalancesQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
+export type GQLContractBalancesQuery = {
+  __typename: 'Query';
+  contractBalances: {
+    __typename: 'ContractBalanceConnection';
+    edges: Array<{
+      __typename: 'ContractBalanceEdge';
+      cursor: string;
+      node: { __typename: 'ContractBalance'; amount: string; assetId: string };
+    }>;
+    pageInfo: {
+      __typename: 'PageInfo';
+      hasNextPage: boolean;
+      hasPreviousPage: boolean;
+      endCursor?: string | null;
+      startCursor?: string | null;
+    };
+  };
+};
 
-export type GQLContractBalancesQuery = { __typename: 'Query', contractBalances: { __typename: 'ContractBalanceConnection', edges: Array<{ __typename: 'ContractBalanceEdge', cursor: string, node: { __typename: 'ContractBalance', amount: string, assetId: string } }>, pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null, startCursor?: string | null } } };
+export type GQLNodeInfoQueryVariables = Exact<{ [key: string]: never }>;
 
-export type GQLNodeInfoQueryVariables = Exact<{ [key: string]: never; }>;
-
-
-export type GQLNodeInfoQuery = { __typename: 'Query', nodeInfo: { __typename: 'NodeInfo', maxDepth: string, maxTx: string, nodeVersion: string, utxoValidation: boolean, vmBacktrace: boolean, peers: Array<{ __typename: 'PeerInfo', addresses: Array<string>, appScore: number, blockHeight?: string | null, clientVersion?: string | null, id: string, lastHeartbeatMs: string }> } };
+export type GQLNodeInfoQuery = {
+  __typename: 'Query';
+  nodeInfo: {
+    __typename: 'NodeInfo';
+    maxDepth: string;
+    maxTx: string;
+    nodeVersion: string;
+    utxoValidation: boolean;
+    vmBacktrace: boolean;
+    peers: Array<{
+      __typename: 'PeerInfo';
+      addresses: Array<string>;
+      appScore: number;
+      blockHeight?: string | null;
+      clientVersion?: string | null;
+      id: string;
+      lastHeartbeatMs: string;
+    }>;
+  };
+};
 
 export const BalanceItemFragmentDoc = gql`
     fragment BalanceItem on Balance {
@@ -3251,10 +5245,19 @@ export const NodeInfoDocument = gql`
 }
     `;
 
-export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
+export type SdkFunctionWrapper = <T>(
+  action: (requestHeaders?: Record<string, string>) => Promise<T>,
+  operationName: string,
+  operationType?: string,
+  variables?: any,
+) => Promise<T>;
 
-
-const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
+const defaultWrapper: SdkFunctionWrapper = (
+  action,
+  _operationName,
+  _operationType,
+  _variables,
+) => action();
 const BalanceDocumentString = print(BalanceDocument);
 const BalancesDocumentString = print(BalancesDocument);
 const BlocksDocumentString = print(BlocksDocument);
@@ -3264,35 +5267,205 @@ const ContractDocumentString = print(ContractDocument);
 const ContractBalanceDocumentString = print(ContractBalanceDocument);
 const ContractBalancesDocumentString = print(ContractBalancesDocument);
 const NodeInfoDocumentString = print(NodeInfoDocument);
-export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
+export function getSdk(
+  client: GraphQLClient,
+  withWrapper: SdkFunctionWrapper = defaultWrapper,
+) {
   return {
-    balance(variables: GQLBalanceQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBalanceQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBalanceQuery>(BalanceDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'balance', 'query', variables);
+    balance(
+      variables: GQLBalanceQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLBalanceQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLBalanceQuery>(BalanceDocumentString, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'balance',
+        'query',
+        variables,
+      );
     },
-    balances(variables: GQLBalancesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBalancesQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBalancesQuery>(BalancesDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'balances', 'query', variables);
+    balances(
+      variables: GQLBalancesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLBalancesQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLBalancesQuery>(
+            BalancesDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'balances',
+        'query',
+        variables,
+      );
     },
-    blocks(variables?: GQLBlocksQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBlocksQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBlocksQuery>(BlocksDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'blocks', 'query', variables);
+    blocks(
+      variables?: GQLBlocksQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLBlocksQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLBlocksQuery>(BlocksDocumentString, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'blocks',
+        'query',
+        variables,
+      );
     },
-    chain(variables?: GQLChainQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLChainQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLChainQuery>(ChainDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'chain', 'query', variables);
+    chain(
+      variables?: GQLChainQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLChainQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLChainQuery>(ChainDocumentString, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'chain',
+        'query',
+        variables,
+      );
     },
-    coins(variables: GQLCoinsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLCoinsQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLCoinsQuery>(CoinsDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'coins', 'query', variables);
+    coins(
+      variables: GQLCoinsQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLCoinsQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLCoinsQuery>(CoinsDocumentString, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        'coins',
+        'query',
+        variables,
+      );
     },
-    contract(variables: GQLContractQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLContractQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLContractQuery>(ContractDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'contract', 'query', variables);
+    contract(
+      variables: GQLContractQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLContractQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLContractQuery>(
+            ContractDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'contract',
+        'query',
+        variables,
+      );
     },
-    contractBalance(variables: GQLContractBalanceQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLContractBalanceQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLContractBalanceQuery>(ContractBalanceDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'contractBalance', 'query', variables);
+    contractBalance(
+      variables: GQLContractBalanceQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLContractBalanceQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLContractBalanceQuery>(
+            ContractBalanceDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'contractBalance',
+        'query',
+        variables,
+      );
     },
-    contractBalances(variables: GQLContractBalancesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLContractBalancesQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLContractBalancesQuery>(ContractBalancesDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'contractBalances', 'query', variables);
+    contractBalances(
+      variables: GQLContractBalancesQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLContractBalancesQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLContractBalancesQuery>(
+            ContractBalancesDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'contractBalances',
+        'query',
+        variables,
+      );
     },
-    nodeInfo(variables?: GQLNodeInfoQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLNodeInfoQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
-        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLNodeInfoQuery>(NodeInfoDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'nodeInfo', 'query', variables);
-    }
+    nodeInfo(
+      variables?: GQLNodeInfoQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<{
+      data: GQLNodeInfoQuery;
+      errors?: GraphQLError[];
+      extensions?: any;
+      headers: Headers;
+      status: number;
+    }> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.rawRequest<GQLNodeInfoQuery>(
+            NodeInfoDocumentString,
+            variables,
+            { ...requestHeaders, ...wrappedRequestHeaders },
+          ),
+        'nodeInfo',
+        'query',
+        variables,
+      );
+    },
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/graphql/src/graphql/generated/sdk-provider.ts
+++ b/packages/graphql/src/graphql/generated/sdk-provider.ts
@@ -1,51 +1,38 @@
-import { GraphQLError, print } from 'graphql';
 import type { GraphQLClient, RequestOptions } from 'graphql-request';
+import { GraphQLError, print } from 'graphql'
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
-export type MakeEmpty<
-  T extends { [key: string]: unknown },
-  K extends keyof T,
-> = { [_ in K]?: never };
-export type Incremental<T> =
-  | T
-  | {
-      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
-    };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string };
-  String: { input: string; output: string };
-  Boolean: { input: boolean; output: boolean };
-  Int: { input: number; output: number };
-  Float: { input: number; output: number };
-  Address: { input: string; output: string };
-  AssetId: { input: string; output: string };
-  BlockId: { input: string; output: string };
-  Bytes32: { input: string; output: string };
-  ContractId: { input: string; output: string };
-  HexString: { input: string; output: string };
-  Nonce: { input: string; output: string };
-  RelayedTransactionId: { input: string; output: string };
-  Salt: { input: string; output: string };
-  Signature: { input: string; output: string };
-  Tai64Timestamp: { input: string; output: string };
-  TransactionId: { input: string; output: string };
-  TxPointer: { input: string; output: string };
-  U16: { input: string; output: string };
-  U32: { input: string; output: string };
-  U64: { input: string; output: string };
-  UtxoId: { input: string; output: string };
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  Address: { input: string; output: string; }
+  AssetId: { input: string; output: string; }
+  BlockId: { input: string; output: string; }
+  Bytes32: { input: string; output: string; }
+  ContractId: { input: string; output: string; }
+  HexString: { input: string; output: string; }
+  Nonce: { input: string; output: string; }
+  RelayedTransactionId: { input: string; output: string; }
+  Salt: { input: string; output: string; }
+  Signature: { input: string; output: string; }
+  Tai64Timestamp: { input: string; output: string; }
+  TransactionId: { input: string; output: string; }
+  TxPointer: { input: string; output: string; }
+  U16: { input: string; output: string; }
+  U32: { input: string; output: string; }
+  U64: { input: string; output: string; }
+  UtxoId: { input: string; output: string; }
 };
 
 export type GQLBalance = {
@@ -114,7 +101,7 @@ export type GQLBlockEdge = {
 };
 
 export enum GQLBlockVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 /** Breakpoint, defined as a tuple of contract ID and relative PC offset inside it */
@@ -211,7 +198,7 @@ export type GQLConsensusParametersPurpose = {
 };
 
 export enum GQLConsensusParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLContract = {
@@ -280,7 +267,7 @@ export type GQLContractParameters = {
 };
 
 export enum GQLContractParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLDependentCost = GQLHeavyOperation | GQLLightOperation;
@@ -309,9 +296,7 @@ export type GQLDryRunTransactionExecutionStatus = {
   status: GQLDryRunTransactionStatus;
 };
 
-export type GQLDryRunTransactionStatus =
-  | GQLDryRunFailureStatus
-  | GQLDryRunSuccessStatus;
+export type GQLDryRunTransactionStatus = GQLDryRunFailureStatus | GQLDryRunSuccessStatus;
 
 export type GQLEstimateGasPrice = {
   __typename: 'EstimateGasPrice';
@@ -345,7 +330,7 @@ export type GQLFeeParameters = {
 };
 
 export enum GQLFeeParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLGasCosts = {
@@ -465,7 +450,7 @@ export type GQLGasCosts = {
 };
 
 export enum GQLGasCostsVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLGenesis = {
@@ -485,10 +470,7 @@ export type GQLGenesis = {
   transactionsRoot: Scalars['Bytes32']['output'];
 };
 
-export type GQLGroupedInput =
-  | GQLGroupedInputCoin
-  | GQLGroupedInputContract
-  | GQLGroupedInputMessage;
+export type GQLGroupedInput = GQLGroupedInputCoin | GQLGroupedInputContract | GQLGroupedInputMessage;
 
 export type GQLGroupedInputCoin = {
   __typename: 'GroupedInputCoin';
@@ -518,13 +500,10 @@ export type GQLGroupedInputMessage = {
 export enum GQLGroupedInputType {
   InputCoin = 'InputCoin',
   InputContract = 'InputContract',
-  InputMessage = 'InputMessage',
+  InputMessage = 'InputMessage'
 }
 
-export type GQLGroupedOutput =
-  | GQLGroupedOutputChanged
-  | GQLGroupedOutputCoin
-  | GQLGroupedOutputContractCreated;
+export type GQLGroupedOutput = GQLGroupedOutputChanged | GQLGroupedOutputCoin | GQLGroupedOutputContractCreated;
 
 export type GQLGroupedOutputChanged = {
   __typename: 'GroupedOutputChanged';
@@ -554,7 +533,7 @@ export type GQLGroupedOutputContractCreated = {
 export enum GQLGroupedOutputType {
   OutputChanged = 'OutputChanged',
   OutputCoin = 'OutputCoin',
-  OutputContractCreated = 'OutputContractCreated',
+  OutputContractCreated = 'OutputContractCreated'
 }
 
 export type GQLHeader = {
@@ -590,7 +569,7 @@ export type GQLHeader = {
 };
 
 export enum GQLHeaderVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLHeavyOperation = {
@@ -709,7 +688,7 @@ export type GQLMessageProof = {
 export enum GQLMessageState {
   NotFound = 'NOT_FOUND',
   Spent = 'SPENT',
-  Unspent = 'UNSPENT',
+  Unspent = 'UNSPENT'
 }
 
 export type GQLMessageStatus = {
@@ -763,9 +742,11 @@ export type GQLMutation = {
   submit: GQLTransaction;
 };
 
+
 export type GQLMutationContinueTxArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type GQLMutationDryRunArgs = {
   gasPrice?: InputMaybe<Scalars['U64']['input']>;
@@ -773,38 +754,46 @@ export type GQLMutationDryRunArgs = {
   utxoValidation?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type GQLMutationEndSessionArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type GQLMutationExecuteArgs = {
   id: Scalars['ID']['input'];
   op: Scalars['String']['input'];
 };
 
+
 export type GQLMutationProduceBlocksArgs = {
   blocksToProduce: Scalars['U32']['input'];
   startTimestamp?: InputMaybe<Scalars['Tai64Timestamp']['input']>;
 };
 
+
 export type GQLMutationResetArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type GQLMutationSetBreakpointArgs = {
   breakpoint: GQLBreakpoint;
   id: Scalars['ID']['input'];
 };
 
+
 export type GQLMutationSetSingleSteppingArgs = {
   enable: Scalars['Boolean']['input'];
   id: Scalars['ID']['input'];
 };
 
+
 export type GQLMutationStartTxArgs = {
   id: Scalars['ID']['input'];
   txJson: Scalars['String']['input'];
 };
+
 
 export type GQLMutationSubmitArgs = {
   tx: Scalars['HexString']['input'];
@@ -837,19 +826,14 @@ export enum GQLOperationType {
   FinalResult = 'FINAL_RESULT',
   FromAccount = 'FROM_ACCOUNT',
   FromContract = 'FROM_CONTRACT',
-  Rootless = 'ROOTLESS',
+  Rootless = 'ROOTLESS'
 }
 
 export type GQLOperationsFilterInput = {
   transactionHash: Scalars['String']['input'];
 };
 
-export type GQLOutput =
-  | GQLChangeOutput
-  | GQLCoinOutput
-  | GQLContractCreated
-  | GQLContractOutput
-  | GQLVariableOutput;
+export type GQLOutput = GQLChangeOutput | GQLCoinOutput | GQLContractCreated | GQLContractOutput | GQLVariableOutput;
 
 /**
  * A separate `Breakpoint` type to be used as an output, as a single
@@ -928,7 +912,7 @@ export type GQLPredicateParameters = {
 };
 
 export enum GQLPredicateParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLProgramState = {
@@ -989,10 +973,12 @@ export type GQLQuery = {
   transactionsByOwner: GQLTransactionConnection;
 };
 
+
 export type GQLQueryBalanceArgs = {
   assetId: Scalars['AssetId']['input'];
   owner: Scalars['Address']['input'];
 };
+
 
 export type GQLQueryBalancesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1002,10 +988,12 @@ export type GQLQueryBalancesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryBlockArgs = {
   height?: InputMaybe<Scalars['U32']['input']>;
   id?: InputMaybe<Scalars['BlockId']['input']>;
 };
+
 
 export type GQLQueryBlocksArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1014,9 +1002,11 @@ export type GQLQueryBlocksArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryCoinArgs = {
   utxoId: Scalars['UtxoId']['input'];
 };
+
 
 export type GQLQueryCoinsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1026,20 +1016,24 @@ export type GQLQueryCoinsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryCoinsToSpendArgs = {
   excludedIds?: InputMaybe<GQLExcludeInput>;
   owner: Scalars['Address']['input'];
   queryPerAsset: Array<GQLSpendQueryElementInput>;
 };
 
+
 export type GQLQueryContractArgs = {
   id: Scalars['ContractId']['input'];
 };
+
 
 export type GQLQueryContractBalanceArgs = {
   asset: Scalars['AssetId']['input'];
   contract: Scalars['ContractId']['input'];
 };
+
 
 export type GQLQueryContractBalancesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1049,6 +1043,7 @@ export type GQLQueryContractBalancesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryContractsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -1056,13 +1051,16 @@ export type GQLQueryContractsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryEstimateGasPriceArgs = {
   blockHorizon?: InputMaybe<Scalars['U32']['input']>;
 };
 
+
 export type GQLQueryEstimatePredicatesArgs = {
   tx: Scalars['HexString']['input'];
 };
+
 
 export type GQLQueryMemoryArgs = {
   id: Scalars['ID']['input'];
@@ -1070,9 +1068,11 @@ export type GQLQueryMemoryArgs = {
   start: Scalars['U32']['input'];
 };
 
+
 export type GQLQueryMessageArgs = {
   nonce: Scalars['Nonce']['input'];
 };
+
 
 export type GQLQueryMessageProofArgs = {
   commitBlockHeight?: InputMaybe<Scalars['U32']['input']>;
@@ -1081,9 +1081,11 @@ export type GQLQueryMessageProofArgs = {
   transactionId: Scalars['TransactionId']['input'];
 };
 
+
 export type GQLQueryMessageStatusArgs = {
   nonce: Scalars['Nonce']['input'];
 };
+
 
 export type GQLQueryMessagesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1093,26 +1095,32 @@ export type GQLQueryMessagesArgs = {
   owner?: InputMaybe<Scalars['Address']['input']>;
 };
 
+
 export type GQLQueryPredicateArgs = {
   address: Scalars['String']['input'];
 };
+
 
 export type GQLQueryRegisterArgs = {
   id: Scalars['ID']['input'];
   register: Scalars['U32']['input'];
 };
 
+
 export type GQLQueryRelayedTransactionStatusArgs = {
   id: Scalars['RelayedTransactionId']['input'];
 };
+
 
 export type GQLQuerySearchArgs = {
   query: Scalars['String']['input'];
 };
 
+
 export type GQLQueryTransactionArgs = {
   id: Scalars['TransactionId']['input'];
 };
+
 
 export type GQLQueryTransactionsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1121,6 +1129,7 @@ export type GQLQueryTransactionsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryTransactionsByBlockIdArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -1128,6 +1137,7 @@ export type GQLQueryTransactionsByBlockIdArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 export type GQLQueryTransactionsByOwnerArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1183,7 +1193,7 @@ export enum GQLReceiptType {
   Revert = 'REVERT',
   ScriptResult = 'SCRIPT_RESULT',
   Transfer = 'TRANSFER',
-  TransferOut = 'TRANSFER_OUT',
+  TransferOut = 'TRANSFER_OUT'
 }
 
 export type GQLRelayedTransactionFailed = {
@@ -1197,7 +1207,7 @@ export type GQLRelayedTransactionStatus = GQLRelayedTransactionFailed;
 export enum GQLReturnType {
   Return = 'RETURN',
   ReturnData = 'RETURN_DATA',
-  Revert = 'REVERT',
+  Revert = 'REVERT'
 }
 
 export type GQLRunResult = {
@@ -1211,7 +1221,7 @@ export enum GQLRunState {
   /** Stopped on a breakpoint */
   Breakpoint = 'BREAKPOINT',
   /** All breakpoints have been processed, and the program has terminated */
-  Completed = 'COMPLETED',
+  Completed = 'COMPLETED'
 }
 
 export type GQLScriptParameters = {
@@ -1222,7 +1232,7 @@ export type GQLScriptParameters = {
 };
 
 export enum GQLScriptParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLSearchAccount = {
@@ -1300,9 +1310,11 @@ export type GQLSubscription = {
   submitAndAwait: GQLTransactionStatus;
 };
 
+
 export type GQLSubscriptionStatusChangeArgs = {
   id: Scalars['TransactionId']['input'];
 };
+
 
 export type GQLSubscriptionSubmitAndAwaitArgs = {
   tx: Scalars['HexString']['input'];
@@ -1393,11 +1405,7 @@ export type GQLTransactionGasCosts = {
   gasUsed?: Maybe<Scalars['U64']['output']>;
 };
 
-export type GQLTransactionStatus =
-  | GQLFailureStatus
-  | GQLSqueezedOutStatus
-  | GQLSubmittedStatus
-  | GQLSuccessStatus;
+export type GQLTransactionStatus = GQLFailureStatus | GQLSqueezedOutStatus | GQLSubmittedStatus | GQLSuccessStatus;
 
 export type GQLTxParameters = {
   __typename: 'TxParameters';
@@ -1411,12 +1419,10 @@ export type GQLTxParameters = {
 };
 
 export enum GQLTxParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
-export type GQLUpgradePurpose =
-  | GQLConsensusParametersPurpose
-  | GQLStateTransitionPurpose;
+export type GQLUpgradePurpose = GQLConsensusParametersPurpose | GQLStateTransitionPurpose;
 
 export type GQLUtxoItem = {
   __typename: 'UtxoItem';
@@ -1438,22 +1444,10 @@ export type GQLBalanceQueryVariables = Exact<{
   owner: Scalars['Address']['input'];
 }>;
 
-export type GQLBalanceQuery = {
-  __typename: 'Query';
-  balance: {
-    __typename: 'Balance';
-    amount: string;
-    assetId: string;
-    owner: string;
-  };
-};
 
-export type GQLBalanceItemFragment = {
-  __typename: 'Balance';
-  amount: string;
-  assetId: string;
-  owner: string;
-};
+export type GQLBalanceQuery = { __typename: 'Query', balance: { __typename: 'Balance', amount: string, assetId: string, owner: string } };
+
+export type GQLBalanceItemFragment = { __typename: 'Balance', amount: string, assetId: string, owner: string };
 
 export type GQLBalancesQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1463,329 +1457,10 @@ export type GQLBalancesQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLBalancesQuery = {
-  __typename: 'Query';
-  balances: {
-    __typename: 'BalanceConnection';
-    nodes: Array<{
-      __typename: 'Balance';
-      amount: string;
-      assetId: string;
-      owner: string;
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      endCursor?: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-    };
-  };
-};
 
-export type GQLBlockItemFragment = {
-  __typename: 'Block';
-  height: string;
-  id: string;
-  consensus:
-    | {
-        __typename: 'Genesis';
-        chainConfigHash: string;
-        coinsRoot: string;
-        contractsRoot: string;
-        messagesRoot: string;
-        transactionsRoot: string;
-      }
-    | { __typename: 'PoAConsensus'; signature: string };
-  header: {
-    __typename: 'Header';
-    applicationHash: string;
-    consensusParametersVersion: string;
-    daHeight: string;
-    eventInboxRoot: string;
-    height: string;
-    id: string;
-    messageOutboxRoot: string;
-    messageReceiptCount: string;
-    prevRoot: string;
-    stateTransitionBytecodeVersion: string;
-    time: string;
-    transactionsCount: string;
-    transactionsRoot: string;
-  };
-  transactions: Array<{
-    __typename: 'Transaction';
-    bytecodeRoot?: string | null;
-    bytecodeWitnessIndex?: string | null;
-    id: string;
-    inputAssetIds?: Array<string> | null;
-    inputContracts?: Array<string> | null;
-    isCreate: boolean;
-    isMint: boolean;
-    isScript: boolean;
-    isUpgrade: boolean;
-    isUpload: boolean;
-    maturity?: string | null;
-    mintAmount?: string | null;
-    mintAssetId?: string | null;
-    mintGasPrice?: string | null;
-    proofSet?: Array<string> | null;
-    rawPayload: string;
-    receiptsRoot?: string | null;
-    salt?: string | null;
-    script?: string | null;
-    scriptData?: string | null;
-    scriptGasLimit?: string | null;
-    storageSlots?: Array<string> | null;
-    subsectionIndex?: string | null;
-    subsectionsNumber?: string | null;
-    txPointer?: string | null;
-    witnesses?: Array<string> | null;
-    inputContract?: {
-      __typename: 'InputContract';
-      balanceRoot: string;
-      contractId: string;
-      stateRoot: string;
-      txPointer: string;
-      utxoId: string;
-    } | null;
-    inputs?: Array<
-      | {
-          __typename: 'InputCoin';
-          amount: string;
-          assetId: string;
-          owner: string;
-          predicate: string;
-          predicateData: string;
-          predicateGasUsed: string;
-          txPointer: string;
-          utxoId: string;
-          witnessIndex: string;
-        }
-      | {
-          __typename: 'InputContract';
-          balanceRoot: string;
-          contractId: string;
-          stateRoot: string;
-          txPointer: string;
-          utxoId: string;
-        }
-      | {
-          __typename: 'InputMessage';
-          amount: string;
-          data: string;
-          nonce: string;
-          predicate: string;
-          predicateData: string;
-          predicateGasUsed: string;
-          recipient: string;
-          sender: string;
-          witnessIndex: string;
-        }
-    > | null;
-    outputContract?: {
-      __typename: 'ContractOutput';
-      balanceRoot: string;
-      inputIndex: string;
-      stateRoot: string;
-    } | null;
-    outputs: Array<
-      | {
-          __typename: 'ChangeOutput';
-          amount: string;
-          assetId: string;
-          to: string;
-        }
-      | {
-          __typename: 'CoinOutput';
-          amount: string;
-          assetId: string;
-          to: string;
-        }
-      | { __typename: 'ContractCreated'; contract: string; stateRoot: string }
-      | {
-          __typename: 'ContractOutput';
-          balanceRoot: string;
-          inputIndex: string;
-          stateRoot: string;
-        }
-      | {
-          __typename: 'VariableOutput';
-          amount: string;
-          assetId: string;
-          to: string;
-        }
-    >;
-    policies?: {
-      __typename: 'Policies';
-      maturity?: string | null;
-      maxFee?: string | null;
-      tip?: string | null;
-      witnessLimit?: string | null;
-    } | null;
-    status?:
-      | {
-          __typename: 'FailureStatus';
-          reason: string;
-          time: string;
-          totalFee: string;
-          totalGas: string;
-          transactionId: string;
-          block: {
-            __typename: 'Block';
-            height: string;
-            id: string;
-            consensus:
-              | {
-                  __typename: 'Genesis';
-                  chainConfigHash: string;
-                  coinsRoot: string;
-                  contractsRoot: string;
-                  messagesRoot: string;
-                  transactionsRoot: string;
-                }
-              | { __typename: 'PoAConsensus'; signature: string };
-            header: {
-              __typename: 'Header';
-              applicationHash: string;
-              consensusParametersVersion: string;
-              daHeight: string;
-              eventInboxRoot: string;
-              height: string;
-              id: string;
-              messageOutboxRoot: string;
-              messageReceiptCount: string;
-              prevRoot: string;
-              stateTransitionBytecodeVersion: string;
-              time: string;
-              transactionsCount: string;
-              transactionsRoot: string;
-            };
-          };
-          programState?: {
-            __typename: 'ProgramState';
-            data: string;
-            returnType: GQLReturnType;
-          } | null;
-          receipts: Array<{
-            __typename: 'Receipt';
-            amount?: string | null;
-            assetId?: string | null;
-            contractId?: string | null;
-            data?: string | null;
-            digest?: string | null;
-            gas?: string | null;
-            gasUsed?: string | null;
-            id?: string | null;
-            is?: string | null;
-            len?: string | null;
-            nonce?: string | null;
-            param1?: string | null;
-            param2?: string | null;
-            pc?: string | null;
-            ptr?: string | null;
-            ra?: string | null;
-            rb?: string | null;
-            rc?: string | null;
-            rd?: string | null;
-            reason?: string | null;
-            receiptType: GQLReceiptType;
-            recipient?: string | null;
-            result?: string | null;
-            sender?: string | null;
-            subId?: string | null;
-            to?: string | null;
-            toAddress?: string | null;
-            val?: string | null;
-          }>;
-        }
-      | { __typename: 'SqueezedOutStatus'; reason: string }
-      | { __typename: 'SubmittedStatus'; time: string }
-      | {
-          __typename: 'SuccessStatus';
-          time: string;
-          totalFee: string;
-          totalGas: string;
-          transactionId: string;
-          block: {
-            __typename: 'Block';
-            height: string;
-            id: string;
-            consensus:
-              | {
-                  __typename: 'Genesis';
-                  chainConfigHash: string;
-                  coinsRoot: string;
-                  contractsRoot: string;
-                  messagesRoot: string;
-                  transactionsRoot: string;
-                }
-              | { __typename: 'PoAConsensus'; signature: string };
-            header: {
-              __typename: 'Header';
-              applicationHash: string;
-              consensusParametersVersion: string;
-              daHeight: string;
-              eventInboxRoot: string;
-              height: string;
-              id: string;
-              messageOutboxRoot: string;
-              messageReceiptCount: string;
-              prevRoot: string;
-              stateTransitionBytecodeVersion: string;
-              time: string;
-              transactionsCount: string;
-              transactionsRoot: string;
-            };
-          };
-          programState?: {
-            __typename: 'ProgramState';
-            data: string;
-            returnType: GQLReturnType;
-          } | null;
-          receipts: Array<{
-            __typename: 'Receipt';
-            amount?: string | null;
-            assetId?: string | null;
-            contractId?: string | null;
-            data?: string | null;
-            digest?: string | null;
-            gas?: string | null;
-            gasUsed?: string | null;
-            id?: string | null;
-            is?: string | null;
-            len?: string | null;
-            nonce?: string | null;
-            param1?: string | null;
-            param2?: string | null;
-            pc?: string | null;
-            ptr?: string | null;
-            ra?: string | null;
-            rb?: string | null;
-            rc?: string | null;
-            rd?: string | null;
-            reason?: string | null;
-            receiptType: GQLReceiptType;
-            recipient?: string | null;
-            result?: string | null;
-            sender?: string | null;
-            subId?: string | null;
-            to?: string | null;
-            toAddress?: string | null;
-            val?: string | null;
-          }>;
-        }
-      | null;
-    upgradePurpose?:
-      | {
-          __typename: 'ConsensusParametersPurpose';
-          checksum: string;
-          witnessIndex: string;
-        }
-      | { __typename: 'StateTransitionPurpose'; root: string }
-      | null;
-  }>;
-};
+export type GQLBalancesQuery = { __typename: 'Query', balances: { __typename: 'BalanceConnection', nodes: Array<{ __typename: 'Balance', amount: string, assetId: string, owner: string }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+
+export type GQLBlockItemFragment = { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> };
 
 export type GQLBlocksQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1794,1587 +1469,13 @@ export type GQLBlocksQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLBlocksQuery = {
-  __typename: 'Query';
-  blocks: {
-    __typename: 'BlockConnection';
-    edges: Array<{
-      __typename: 'BlockEdge';
-      cursor: string;
-      node: {
-        __typename: 'Block';
-        height: string;
-        id: string;
-        consensus:
-          | {
-              __typename: 'Genesis';
-              chainConfigHash: string;
-              coinsRoot: string;
-              contractsRoot: string;
-              messagesRoot: string;
-              transactionsRoot: string;
-            }
-          | { __typename: 'PoAConsensus'; signature: string };
-        header: {
-          __typename: 'Header';
-          applicationHash: string;
-          consensusParametersVersion: string;
-          daHeight: string;
-          eventInboxRoot: string;
-          height: string;
-          id: string;
-          messageOutboxRoot: string;
-          messageReceiptCount: string;
-          prevRoot: string;
-          stateTransitionBytecodeVersion: string;
-          time: string;
-          transactionsCount: string;
-          transactionsRoot: string;
-        };
-        transactions: Array<{
-          __typename: 'Transaction';
-          bytecodeRoot?: string | null;
-          bytecodeWitnessIndex?: string | null;
-          id: string;
-          inputAssetIds?: Array<string> | null;
-          inputContracts?: Array<string> | null;
-          isCreate: boolean;
-          isMint: boolean;
-          isScript: boolean;
-          isUpgrade: boolean;
-          isUpload: boolean;
-          maturity?: string | null;
-          mintAmount?: string | null;
-          mintAssetId?: string | null;
-          mintGasPrice?: string | null;
-          proofSet?: Array<string> | null;
-          rawPayload: string;
-          receiptsRoot?: string | null;
-          salt?: string | null;
-          script?: string | null;
-          scriptData?: string | null;
-          scriptGasLimit?: string | null;
-          storageSlots?: Array<string> | null;
-          subsectionIndex?: string | null;
-          subsectionsNumber?: string | null;
-          txPointer?: string | null;
-          witnesses?: Array<string> | null;
-          inputContract?: {
-            __typename: 'InputContract';
-            balanceRoot: string;
-            contractId: string;
-            stateRoot: string;
-            txPointer: string;
-            utxoId: string;
-          } | null;
-          inputs?: Array<
-            | {
-                __typename: 'InputCoin';
-                amount: string;
-                assetId: string;
-                owner: string;
-                predicate: string;
-                predicateData: string;
-                predicateGasUsed: string;
-                txPointer: string;
-                utxoId: string;
-                witnessIndex: string;
-              }
-            | {
-                __typename: 'InputContract';
-                balanceRoot: string;
-                contractId: string;
-                stateRoot: string;
-                txPointer: string;
-                utxoId: string;
-              }
-            | {
-                __typename: 'InputMessage';
-                amount: string;
-                data: string;
-                nonce: string;
-                predicate: string;
-                predicateData: string;
-                predicateGasUsed: string;
-                recipient: string;
-                sender: string;
-                witnessIndex: string;
-              }
-          > | null;
-          outputContract?: {
-            __typename: 'ContractOutput';
-            balanceRoot: string;
-            inputIndex: string;
-            stateRoot: string;
-          } | null;
-          outputs: Array<
-            | {
-                __typename: 'ChangeOutput';
-                amount: string;
-                assetId: string;
-                to: string;
-              }
-            | {
-                __typename: 'CoinOutput';
-                amount: string;
-                assetId: string;
-                to: string;
-              }
-            | {
-                __typename: 'ContractCreated';
-                contract: string;
-                stateRoot: string;
-              }
-            | {
-                __typename: 'ContractOutput';
-                balanceRoot: string;
-                inputIndex: string;
-                stateRoot: string;
-              }
-            | {
-                __typename: 'VariableOutput';
-                amount: string;
-                assetId: string;
-                to: string;
-              }
-          >;
-          policies?: {
-            __typename: 'Policies';
-            maturity?: string | null;
-            maxFee?: string | null;
-            tip?: string | null;
-            witnessLimit?: string | null;
-          } | null;
-          status?:
-            | {
-                __typename: 'FailureStatus';
-                reason: string;
-                time: string;
-                totalFee: string;
-                totalGas: string;
-                transactionId: string;
-                block: {
-                  __typename: 'Block';
-                  height: string;
-                  id: string;
-                  consensus:
-                    | {
-                        __typename: 'Genesis';
-                        chainConfigHash: string;
-                        coinsRoot: string;
-                        contractsRoot: string;
-                        messagesRoot: string;
-                        transactionsRoot: string;
-                      }
-                    | { __typename: 'PoAConsensus'; signature: string };
-                  header: {
-                    __typename: 'Header';
-                    applicationHash: string;
-                    consensusParametersVersion: string;
-                    daHeight: string;
-                    eventInboxRoot: string;
-                    height: string;
-                    id: string;
-                    messageOutboxRoot: string;
-                    messageReceiptCount: string;
-                    prevRoot: string;
-                    stateTransitionBytecodeVersion: string;
-                    time: string;
-                    transactionsCount: string;
-                    transactionsRoot: string;
-                  };
-                };
-                programState?: {
-                  __typename: 'ProgramState';
-                  data: string;
-                  returnType: GQLReturnType;
-                } | null;
-                receipts: Array<{
-                  __typename: 'Receipt';
-                  amount?: string | null;
-                  assetId?: string | null;
-                  contractId?: string | null;
-                  data?: string | null;
-                  digest?: string | null;
-                  gas?: string | null;
-                  gasUsed?: string | null;
-                  id?: string | null;
-                  is?: string | null;
-                  len?: string | null;
-                  nonce?: string | null;
-                  param1?: string | null;
-                  param2?: string | null;
-                  pc?: string | null;
-                  ptr?: string | null;
-                  ra?: string | null;
-                  rb?: string | null;
-                  rc?: string | null;
-                  rd?: string | null;
-                  reason?: string | null;
-                  receiptType: GQLReceiptType;
-                  recipient?: string | null;
-                  result?: string | null;
-                  sender?: string | null;
-                  subId?: string | null;
-                  to?: string | null;
-                  toAddress?: string | null;
-                  val?: string | null;
-                }>;
-              }
-            | { __typename: 'SqueezedOutStatus'; reason: string }
-            | { __typename: 'SubmittedStatus'; time: string }
-            | {
-                __typename: 'SuccessStatus';
-                time: string;
-                totalFee: string;
-                totalGas: string;
-                transactionId: string;
-                block: {
-                  __typename: 'Block';
-                  height: string;
-                  id: string;
-                  consensus:
-                    | {
-                        __typename: 'Genesis';
-                        chainConfigHash: string;
-                        coinsRoot: string;
-                        contractsRoot: string;
-                        messagesRoot: string;
-                        transactionsRoot: string;
-                      }
-                    | { __typename: 'PoAConsensus'; signature: string };
-                  header: {
-                    __typename: 'Header';
-                    applicationHash: string;
-                    consensusParametersVersion: string;
-                    daHeight: string;
-                    eventInboxRoot: string;
-                    height: string;
-                    id: string;
-                    messageOutboxRoot: string;
-                    messageReceiptCount: string;
-                    prevRoot: string;
-                    stateTransitionBytecodeVersion: string;
-                    time: string;
-                    transactionsCount: string;
-                    transactionsRoot: string;
-                  };
-                };
-                programState?: {
-                  __typename: 'ProgramState';
-                  data: string;
-                  returnType: GQLReturnType;
-                } | null;
-                receipts: Array<{
-                  __typename: 'Receipt';
-                  amount?: string | null;
-                  assetId?: string | null;
-                  contractId?: string | null;
-                  data?: string | null;
-                  digest?: string | null;
-                  gas?: string | null;
-                  gasUsed?: string | null;
-                  id?: string | null;
-                  is?: string | null;
-                  len?: string | null;
-                  nonce?: string | null;
-                  param1?: string | null;
-                  param2?: string | null;
-                  pc?: string | null;
-                  ptr?: string | null;
-                  ra?: string | null;
-                  rb?: string | null;
-                  rc?: string | null;
-                  rd?: string | null;
-                  reason?: string | null;
-                  receiptType: GQLReceiptType;
-                  recipient?: string | null;
-                  result?: string | null;
-                  sender?: string | null;
-                  subId?: string | null;
-                  to?: string | null;
-                  toAddress?: string | null;
-                  val?: string | null;
-                }>;
-              }
-            | null;
-          upgradePurpose?:
-            | {
-                __typename: 'ConsensusParametersPurpose';
-                checksum: string;
-                witnessIndex: string;
-              }
-            | { __typename: 'StateTransitionPurpose'; root: string }
-            | null;
-        }>;
-      };
-    }>;
-    nodes: Array<{
-      __typename: 'Block';
-      height: string;
-      id: string;
-      consensus:
-        | {
-            __typename: 'Genesis';
-            chainConfigHash: string;
-            coinsRoot: string;
-            contractsRoot: string;
-            messagesRoot: string;
-            transactionsRoot: string;
-          }
-        | { __typename: 'PoAConsensus'; signature: string };
-      header: {
-        __typename: 'Header';
-        applicationHash: string;
-        consensusParametersVersion: string;
-        daHeight: string;
-        eventInboxRoot: string;
-        height: string;
-        id: string;
-        messageOutboxRoot: string;
-        messageReceiptCount: string;
-        prevRoot: string;
-        stateTransitionBytecodeVersion: string;
-        time: string;
-        transactionsCount: string;
-        transactionsRoot: string;
-      };
-      transactions: Array<{
-        __typename: 'Transaction';
-        bytecodeRoot?: string | null;
-        bytecodeWitnessIndex?: string | null;
-        id: string;
-        inputAssetIds?: Array<string> | null;
-        inputContracts?: Array<string> | null;
-        isCreate: boolean;
-        isMint: boolean;
-        isScript: boolean;
-        isUpgrade: boolean;
-        isUpload: boolean;
-        maturity?: string | null;
-        mintAmount?: string | null;
-        mintAssetId?: string | null;
-        mintGasPrice?: string | null;
-        proofSet?: Array<string> | null;
-        rawPayload: string;
-        receiptsRoot?: string | null;
-        salt?: string | null;
-        script?: string | null;
-        scriptData?: string | null;
-        scriptGasLimit?: string | null;
-        storageSlots?: Array<string> | null;
-        subsectionIndex?: string | null;
-        subsectionsNumber?: string | null;
-        txPointer?: string | null;
-        witnesses?: Array<string> | null;
-        inputContract?: {
-          __typename: 'InputContract';
-          balanceRoot: string;
-          contractId: string;
-          stateRoot: string;
-          txPointer: string;
-          utxoId: string;
-        } | null;
-        inputs?: Array<
-          | {
-              __typename: 'InputCoin';
-              amount: string;
-              assetId: string;
-              owner: string;
-              predicate: string;
-              predicateData: string;
-              predicateGasUsed: string;
-              txPointer: string;
-              utxoId: string;
-              witnessIndex: string;
-            }
-          | {
-              __typename: 'InputContract';
-              balanceRoot: string;
-              contractId: string;
-              stateRoot: string;
-              txPointer: string;
-              utxoId: string;
-            }
-          | {
-              __typename: 'InputMessage';
-              amount: string;
-              data: string;
-              nonce: string;
-              predicate: string;
-              predicateData: string;
-              predicateGasUsed: string;
-              recipient: string;
-              sender: string;
-              witnessIndex: string;
-            }
-        > | null;
-        outputContract?: {
-          __typename: 'ContractOutput';
-          balanceRoot: string;
-          inputIndex: string;
-          stateRoot: string;
-        } | null;
-        outputs: Array<
-          | {
-              __typename: 'ChangeOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-          | {
-              __typename: 'CoinOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-          | {
-              __typename: 'ContractCreated';
-              contract: string;
-              stateRoot: string;
-            }
-          | {
-              __typename: 'ContractOutput';
-              balanceRoot: string;
-              inputIndex: string;
-              stateRoot: string;
-            }
-          | {
-              __typename: 'VariableOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-        >;
-        policies?: {
-          __typename: 'Policies';
-          maturity?: string | null;
-          maxFee?: string | null;
-          tip?: string | null;
-          witnessLimit?: string | null;
-        } | null;
-        status?:
-          | {
-              __typename: 'FailureStatus';
-              reason: string;
-              time: string;
-              totalFee: string;
-              totalGas: string;
-              transactionId: string;
-              block: {
-                __typename: 'Block';
-                height: string;
-                id: string;
-                consensus:
-                  | {
-                      __typename: 'Genesis';
-                      chainConfigHash: string;
-                      coinsRoot: string;
-                      contractsRoot: string;
-                      messagesRoot: string;
-                      transactionsRoot: string;
-                    }
-                  | { __typename: 'PoAConsensus'; signature: string };
-                header: {
-                  __typename: 'Header';
-                  applicationHash: string;
-                  consensusParametersVersion: string;
-                  daHeight: string;
-                  eventInboxRoot: string;
-                  height: string;
-                  id: string;
-                  messageOutboxRoot: string;
-                  messageReceiptCount: string;
-                  prevRoot: string;
-                  stateTransitionBytecodeVersion: string;
-                  time: string;
-                  transactionsCount: string;
-                  transactionsRoot: string;
-                };
-              };
-              programState?: {
-                __typename: 'ProgramState';
-                data: string;
-                returnType: GQLReturnType;
-              } | null;
-              receipts: Array<{
-                __typename: 'Receipt';
-                amount?: string | null;
-                assetId?: string | null;
-                contractId?: string | null;
-                data?: string | null;
-                digest?: string | null;
-                gas?: string | null;
-                gasUsed?: string | null;
-                id?: string | null;
-                is?: string | null;
-                len?: string | null;
-                nonce?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                pc?: string | null;
-                ptr?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                reason?: string | null;
-                receiptType: GQLReceiptType;
-                recipient?: string | null;
-                result?: string | null;
-                sender?: string | null;
-                subId?: string | null;
-                to?: string | null;
-                toAddress?: string | null;
-                val?: string | null;
-              }>;
-            }
-          | { __typename: 'SqueezedOutStatus'; reason: string }
-          | { __typename: 'SubmittedStatus'; time: string }
-          | {
-              __typename: 'SuccessStatus';
-              time: string;
-              totalFee: string;
-              totalGas: string;
-              transactionId: string;
-              block: {
-                __typename: 'Block';
-                height: string;
-                id: string;
-                consensus:
-                  | {
-                      __typename: 'Genesis';
-                      chainConfigHash: string;
-                      coinsRoot: string;
-                      contractsRoot: string;
-                      messagesRoot: string;
-                      transactionsRoot: string;
-                    }
-                  | { __typename: 'PoAConsensus'; signature: string };
-                header: {
-                  __typename: 'Header';
-                  applicationHash: string;
-                  consensusParametersVersion: string;
-                  daHeight: string;
-                  eventInboxRoot: string;
-                  height: string;
-                  id: string;
-                  messageOutboxRoot: string;
-                  messageReceiptCount: string;
-                  prevRoot: string;
-                  stateTransitionBytecodeVersion: string;
-                  time: string;
-                  transactionsCount: string;
-                  transactionsRoot: string;
-                };
-              };
-              programState?: {
-                __typename: 'ProgramState';
-                data: string;
-                returnType: GQLReturnType;
-              } | null;
-              receipts: Array<{
-                __typename: 'Receipt';
-                amount?: string | null;
-                assetId?: string | null;
-                contractId?: string | null;
-                data?: string | null;
-                digest?: string | null;
-                gas?: string | null;
-                gasUsed?: string | null;
-                id?: string | null;
-                is?: string | null;
-                len?: string | null;
-                nonce?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                pc?: string | null;
-                ptr?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                reason?: string | null;
-                receiptType: GQLReceiptType;
-                recipient?: string | null;
-                result?: string | null;
-                sender?: string | null;
-                subId?: string | null;
-                to?: string | null;
-                toAddress?: string | null;
-                val?: string | null;
-              }>;
-            }
-          | null;
-        upgradePurpose?:
-          | {
-              __typename: 'ConsensusParametersPurpose';
-              checksum: string;
-              witnessIndex: string;
-            }
-          | { __typename: 'StateTransitionPurpose'; root: string }
-          | null;
-      }>;
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      endCursor?: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-    };
-  };
-};
 
-export type GQLChainQueryVariables = Exact<{ [key: string]: never }>;
+export type GQLBlocksQuery = { __typename: 'Query', blocks: { __typename: 'BlockConnection', edges: Array<{ __typename: 'BlockEdge', cursor: string, node: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> } }>, nodes: Array<{ __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string } }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
-export type GQLChainQuery = {
-  __typename: 'Query';
-  chain: {
-    __typename: 'ChainInfo';
-    daHeight: string;
-    name: string;
-    consensusParameters: {
-      __typename: 'ConsensusParameters';
-      baseAssetId: string;
-      blockGasLimit: string;
-      chainId: string;
-      privilegedAddress: string;
-      contractParams: {
-        __typename: 'ContractParameters';
-        contractMaxSize: string;
-        maxStorageSlots: string;
-      };
-      feeParams: {
-        __typename: 'FeeParameters';
-        gasPerByte: string;
-        gasPriceFactor: string;
-      };
-      gasCosts: {
-        __typename: 'GasCosts';
-        add: string;
-        addi: string;
-        aloc: string;
-        and: string;
-        andi: string;
-        bal: string;
-        bhei: string;
-        bhsh: string;
-        burn: string;
-        cb: string;
-        cfei: string;
-        cfsi: string;
-        div: string;
-        divi: string;
-        eck1: string;
-        ecr1: string;
-        ed19: string;
-        eq: string;
-        exp: string;
-        expi: string;
-        flag: string;
-        gm: string;
-        gt: string;
-        gtf: string;
-        ji: string;
-        jmp: string;
-        jmpb: string;
-        jmpf: string;
-        jne: string;
-        jneb: string;
-        jnef: string;
-        jnei: string;
-        jnzb: string;
-        jnzf: string;
-        jnzi: string;
-        lb: string;
-        log: string;
-        lt: string;
-        lw: string;
-        mint: string;
-        mldv: string;
-        mlog: string;
-        modOp: string;
-        modi: string;
-        moveOp: string;
-        movi: string;
-        mroo: string;
-        mul: string;
-        muli: string;
-        newStoragePerByte: string;
-        noop: string;
-        not: string;
-        or: string;
-        ori: string;
-        poph: string;
-        popl: string;
-        pshh: string;
-        pshl: string;
-        ret: string;
-        rvrt: string;
-        sb: string;
-        sll: string;
-        slli: string;
-        srl: string;
-        srli: string;
-        srw: string;
-        sub: string;
-        subi: string;
-        sw: string;
-        sww: string;
-        time: string;
-        tr: string;
-        tro: string;
-        wdam: string;
-        wdcm: string;
-        wddv: string;
-        wdmd: string;
-        wdml: string;
-        wdmm: string;
-        wdop: string;
-        wqam: string;
-        wqcm: string;
-        wqdv: string;
-        wqmd: string;
-        wqml: string;
-        wqmm: string;
-        wqop: string;
-        xor: string;
-        xori: string;
-        call:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        ccp:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        contractRoot:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        croo:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        csiz:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        k256:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        ldc:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        logd:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        mcl:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        mcli:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        mcp:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        mcpi:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        meq:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        retd:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        s256:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        scwq:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        smo:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        srwq:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        stateRoot:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        swwq:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        vmInitialization:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      };
-      predicateParams: {
-        __typename: 'PredicateParameters';
-        maxGasPerPredicate: string;
-        maxMessageDataLength: string;
-        maxPredicateDataLength: string;
-        maxPredicateLength: string;
-      };
-      scriptParams: {
-        __typename: 'ScriptParameters';
-        maxScriptDataLength: string;
-        maxScriptLength: string;
-      };
-      txParams: {
-        __typename: 'TxParameters';
-        maxBytecodeSubsections: string;
-        maxGasPerTx: string;
-        maxInputs: string;
-        maxOutputs: string;
-        maxSize: string;
-        maxWitnesses: string;
-      };
-    };
-    gasCosts: {
-      __typename: 'GasCosts';
-      add: string;
-      addi: string;
-      aloc: string;
-      and: string;
-      andi: string;
-      bal: string;
-      bhei: string;
-      bhsh: string;
-      burn: string;
-      cb: string;
-      cfei: string;
-      cfsi: string;
-      div: string;
-      divi: string;
-      eck1: string;
-      ecr1: string;
-      ed19: string;
-      eq: string;
-      exp: string;
-      expi: string;
-      flag: string;
-      gm: string;
-      gt: string;
-      gtf: string;
-      ji: string;
-      jmp: string;
-      jmpb: string;
-      jmpf: string;
-      jne: string;
-      jneb: string;
-      jnef: string;
-      jnei: string;
-      jnzb: string;
-      jnzf: string;
-      jnzi: string;
-      lb: string;
-      log: string;
-      lt: string;
-      lw: string;
-      mint: string;
-      mldv: string;
-      mlog: string;
-      modOp: string;
-      modi: string;
-      moveOp: string;
-      movi: string;
-      mroo: string;
-      mul: string;
-      muli: string;
-      newStoragePerByte: string;
-      noop: string;
-      not: string;
-      or: string;
-      ori: string;
-      poph: string;
-      popl: string;
-      pshh: string;
-      pshl: string;
-      ret: string;
-      rvrt: string;
-      sb: string;
-      sll: string;
-      slli: string;
-      srl: string;
-      srli: string;
-      srw: string;
-      sub: string;
-      subi: string;
-      sw: string;
-      sww: string;
-      time: string;
-      tr: string;
-      tro: string;
-      wdam: string;
-      wdcm: string;
-      wddv: string;
-      wdmd: string;
-      wdml: string;
-      wdmm: string;
-      wdop: string;
-      wqam: string;
-      wqcm: string;
-      wqdv: string;
-      wqmd: string;
-      wqml: string;
-      wqmm: string;
-      wqop: string;
-      xor: string;
-      xori: string;
-      call:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      ccp:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      contractRoot:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      croo:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      csiz:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      k256:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      ldc:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      logd:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      mcl:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      mcli:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      mcp:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      mcpi:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      meq:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      retd:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      s256:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      scwq:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      smo:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      srwq:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      stateRoot:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      swwq:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      vmInitialization:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-    };
-    latestBlock: {
-      __typename: 'Block';
-      height: string;
-      id: string;
-      consensus:
-        | {
-            __typename: 'Genesis';
-            chainConfigHash: string;
-            coinsRoot: string;
-            contractsRoot: string;
-            messagesRoot: string;
-            transactionsRoot: string;
-          }
-        | { __typename: 'PoAConsensus'; signature: string };
-      header: {
-        __typename: 'Header';
-        applicationHash: string;
-        consensusParametersVersion: string;
-        daHeight: string;
-        eventInboxRoot: string;
-        height: string;
-        id: string;
-        messageOutboxRoot: string;
-        messageReceiptCount: string;
-        prevRoot: string;
-        stateTransitionBytecodeVersion: string;
-        time: string;
-        transactionsCount: string;
-        transactionsRoot: string;
-      };
-      transactions: Array<{
-        __typename: 'Transaction';
-        bytecodeRoot?: string | null;
-        bytecodeWitnessIndex?: string | null;
-        id: string;
-        inputAssetIds?: Array<string> | null;
-        inputContracts?: Array<string> | null;
-        isCreate: boolean;
-        isMint: boolean;
-        isScript: boolean;
-        isUpgrade: boolean;
-        isUpload: boolean;
-        maturity?: string | null;
-        mintAmount?: string | null;
-        mintAssetId?: string | null;
-        mintGasPrice?: string | null;
-        proofSet?: Array<string> | null;
-        rawPayload: string;
-        receiptsRoot?: string | null;
-        salt?: string | null;
-        script?: string | null;
-        scriptData?: string | null;
-        scriptGasLimit?: string | null;
-        storageSlots?: Array<string> | null;
-        subsectionIndex?: string | null;
-        subsectionsNumber?: string | null;
-        txPointer?: string | null;
-        witnesses?: Array<string> | null;
-        inputContract?: {
-          __typename: 'InputContract';
-          balanceRoot: string;
-          contractId: string;
-          stateRoot: string;
-          txPointer: string;
-          utxoId: string;
-        } | null;
-        inputs?: Array<
-          | {
-              __typename: 'InputCoin';
-              amount: string;
-              assetId: string;
-              owner: string;
-              predicate: string;
-              predicateData: string;
-              predicateGasUsed: string;
-              txPointer: string;
-              utxoId: string;
-              witnessIndex: string;
-            }
-          | {
-              __typename: 'InputContract';
-              balanceRoot: string;
-              contractId: string;
-              stateRoot: string;
-              txPointer: string;
-              utxoId: string;
-            }
-          | {
-              __typename: 'InputMessage';
-              amount: string;
-              data: string;
-              nonce: string;
-              predicate: string;
-              predicateData: string;
-              predicateGasUsed: string;
-              recipient: string;
-              sender: string;
-              witnessIndex: string;
-            }
-        > | null;
-        outputContract?: {
-          __typename: 'ContractOutput';
-          balanceRoot: string;
-          inputIndex: string;
-          stateRoot: string;
-        } | null;
-        outputs: Array<
-          | {
-              __typename: 'ChangeOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-          | {
-              __typename: 'CoinOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-          | {
-              __typename: 'ContractCreated';
-              contract: string;
-              stateRoot: string;
-            }
-          | {
-              __typename: 'ContractOutput';
-              balanceRoot: string;
-              inputIndex: string;
-              stateRoot: string;
-            }
-          | {
-              __typename: 'VariableOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-        >;
-        policies?: {
-          __typename: 'Policies';
-          maturity?: string | null;
-          maxFee?: string | null;
-          tip?: string | null;
-          witnessLimit?: string | null;
-        } | null;
-        status?:
-          | {
-              __typename: 'FailureStatus';
-              reason: string;
-              time: string;
-              totalFee: string;
-              totalGas: string;
-              transactionId: string;
-              block: {
-                __typename: 'Block';
-                height: string;
-                id: string;
-                consensus:
-                  | {
-                      __typename: 'Genesis';
-                      chainConfigHash: string;
-                      coinsRoot: string;
-                      contractsRoot: string;
-                      messagesRoot: string;
-                      transactionsRoot: string;
-                    }
-                  | { __typename: 'PoAConsensus'; signature: string };
-                header: {
-                  __typename: 'Header';
-                  applicationHash: string;
-                  consensusParametersVersion: string;
-                  daHeight: string;
-                  eventInboxRoot: string;
-                  height: string;
-                  id: string;
-                  messageOutboxRoot: string;
-                  messageReceiptCount: string;
-                  prevRoot: string;
-                  stateTransitionBytecodeVersion: string;
-                  time: string;
-                  transactionsCount: string;
-                  transactionsRoot: string;
-                };
-                transactions: Array<{
-                  __typename: 'Transaction';
-                  bytecodeRoot?: string | null;
-                  bytecodeWitnessIndex?: string | null;
-                  id: string;
-                  inputAssetIds?: Array<string> | null;
-                  inputContracts?: Array<string> | null;
-                  isCreate: boolean;
-                  isMint: boolean;
-                  isScript: boolean;
-                  isUpgrade: boolean;
-                  isUpload: boolean;
-                  maturity?: string | null;
-                  mintAmount?: string | null;
-                  mintAssetId?: string | null;
-                  mintGasPrice?: string | null;
-                  proofSet?: Array<string> | null;
-                  rawPayload: string;
-                  receiptsRoot?: string | null;
-                  salt?: string | null;
-                  script?: string | null;
-                  scriptData?: string | null;
-                  scriptGasLimit?: string | null;
-                  storageSlots?: Array<string> | null;
-                  subsectionIndex?: string | null;
-                  subsectionsNumber?: string | null;
-                  txPointer?: string | null;
-                  witnesses?: Array<string> | null;
-                  inputContract?: {
-                    __typename: 'InputContract';
-                    balanceRoot: string;
-                    contractId: string;
-                    stateRoot: string;
-                    txPointer: string;
-                    utxoId: string;
-                  } | null;
-                  inputs?: Array<
-                    | {
-                        __typename: 'InputCoin';
-                        amount: string;
-                        assetId: string;
-                        owner: string;
-                        predicate: string;
-                        predicateData: string;
-                        predicateGasUsed: string;
-                        txPointer: string;
-                        utxoId: string;
-                        witnessIndex: string;
-                      }
-                    | {
-                        __typename: 'InputContract';
-                        balanceRoot: string;
-                        contractId: string;
-                        stateRoot: string;
-                        txPointer: string;
-                        utxoId: string;
-                      }
-                    | {
-                        __typename: 'InputMessage';
-                        amount: string;
-                        data: string;
-                        nonce: string;
-                        predicate: string;
-                        predicateData: string;
-                        predicateGasUsed: string;
-                        recipient: string;
-                        sender: string;
-                        witnessIndex: string;
-                      }
-                  > | null;
-                  outputContract?: {
-                    __typename: 'ContractOutput';
-                    balanceRoot: string;
-                    inputIndex: string;
-                    stateRoot: string;
-                  } | null;
-                  outputs: Array<
-                    | {
-                        __typename: 'ChangeOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                    | {
-                        __typename: 'CoinOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                    | {
-                        __typename: 'ContractCreated';
-                        contract: string;
-                        stateRoot: string;
-                      }
-                    | {
-                        __typename: 'ContractOutput';
-                        balanceRoot: string;
-                        inputIndex: string;
-                        stateRoot: string;
-                      }
-                    | {
-                        __typename: 'VariableOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                  >;
-                  policies?: {
-                    __typename: 'Policies';
-                    maturity?: string | null;
-                    maxFee?: string | null;
-                    tip?: string | null;
-                    witnessLimit?: string | null;
-                  } | null;
-                  status?:
-                    | {
-                        __typename: 'FailureStatus';
-                        reason: string;
-                        time: string;
-                        totalFee: string;
-                        totalGas: string;
-                        transactionId: string;
-                      }
-                    | { __typename: 'SqueezedOutStatus'; reason: string }
-                    | { __typename: 'SubmittedStatus'; time: string }
-                    | {
-                        __typename: 'SuccessStatus';
-                        time: string;
-                        totalFee: string;
-                        totalGas: string;
-                        transactionId: string;
-                      }
-                    | null;
-                  upgradePurpose?:
-                    | {
-                        __typename: 'ConsensusParametersPurpose';
-                        checksum: string;
-                        witnessIndex: string;
-                      }
-                    | { __typename: 'StateTransitionPurpose'; root: string }
-                    | null;
-                }>;
-              };
-              programState?: {
-                __typename: 'ProgramState';
-                data: string;
-                returnType: GQLReturnType;
-              } | null;
-              receipts: Array<{
-                __typename: 'Receipt';
-                amount?: string | null;
-                assetId?: string | null;
-                contractId?: string | null;
-                data?: string | null;
-                digest?: string | null;
-                gas?: string | null;
-                gasUsed?: string | null;
-                id?: string | null;
-                is?: string | null;
-                len?: string | null;
-                nonce?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                pc?: string | null;
-                ptr?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                reason?: string | null;
-                receiptType: GQLReceiptType;
-                recipient?: string | null;
-                result?: string | null;
-                sender?: string | null;
-                subId?: string | null;
-                to?: string | null;
-                toAddress?: string | null;
-                val?: string | null;
-              }>;
-            }
-          | { __typename: 'SqueezedOutStatus'; reason: string }
-          | { __typename: 'SubmittedStatus'; time: string }
-          | {
-              __typename: 'SuccessStatus';
-              time: string;
-              totalFee: string;
-              totalGas: string;
-              transactionId: string;
-              block: {
-                __typename: 'Block';
-                height: string;
-                id: string;
-                consensus:
-                  | {
-                      __typename: 'Genesis';
-                      chainConfigHash: string;
-                      coinsRoot: string;
-                      contractsRoot: string;
-                      messagesRoot: string;
-                      transactionsRoot: string;
-                    }
-                  | { __typename: 'PoAConsensus'; signature: string };
-                header: {
-                  __typename: 'Header';
-                  applicationHash: string;
-                  consensusParametersVersion: string;
-                  daHeight: string;
-                  eventInboxRoot: string;
-                  height: string;
-                  id: string;
-                  messageOutboxRoot: string;
-                  messageReceiptCount: string;
-                  prevRoot: string;
-                  stateTransitionBytecodeVersion: string;
-                  time: string;
-                  transactionsCount: string;
-                  transactionsRoot: string;
-                };
-                transactions: Array<{
-                  __typename: 'Transaction';
-                  bytecodeRoot?: string | null;
-                  bytecodeWitnessIndex?: string | null;
-                  id: string;
-                  inputAssetIds?: Array<string> | null;
-                  inputContracts?: Array<string> | null;
-                  isCreate: boolean;
-                  isMint: boolean;
-                  isScript: boolean;
-                  isUpgrade: boolean;
-                  isUpload: boolean;
-                  maturity?: string | null;
-                  mintAmount?: string | null;
-                  mintAssetId?: string | null;
-                  mintGasPrice?: string | null;
-                  proofSet?: Array<string> | null;
-                  rawPayload: string;
-                  receiptsRoot?: string | null;
-                  salt?: string | null;
-                  script?: string | null;
-                  scriptData?: string | null;
-                  scriptGasLimit?: string | null;
-                  storageSlots?: Array<string> | null;
-                  subsectionIndex?: string | null;
-                  subsectionsNumber?: string | null;
-                  txPointer?: string | null;
-                  witnesses?: Array<string> | null;
-                  inputContract?: {
-                    __typename: 'InputContract';
-                    balanceRoot: string;
-                    contractId: string;
-                    stateRoot: string;
-                    txPointer: string;
-                    utxoId: string;
-                  } | null;
-                  inputs?: Array<
-                    | {
-                        __typename: 'InputCoin';
-                        amount: string;
-                        assetId: string;
-                        owner: string;
-                        predicate: string;
-                        predicateData: string;
-                        predicateGasUsed: string;
-                        txPointer: string;
-                        utxoId: string;
-                        witnessIndex: string;
-                      }
-                    | {
-                        __typename: 'InputContract';
-                        balanceRoot: string;
-                        contractId: string;
-                        stateRoot: string;
-                        txPointer: string;
-                        utxoId: string;
-                      }
-                    | {
-                        __typename: 'InputMessage';
-                        amount: string;
-                        data: string;
-                        nonce: string;
-                        predicate: string;
-                        predicateData: string;
-                        predicateGasUsed: string;
-                        recipient: string;
-                        sender: string;
-                        witnessIndex: string;
-                      }
-                  > | null;
-                  outputContract?: {
-                    __typename: 'ContractOutput';
-                    balanceRoot: string;
-                    inputIndex: string;
-                    stateRoot: string;
-                  } | null;
-                  outputs: Array<
-                    | {
-                        __typename: 'ChangeOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                    | {
-                        __typename: 'CoinOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                    | {
-                        __typename: 'ContractCreated';
-                        contract: string;
-                        stateRoot: string;
-                      }
-                    | {
-                        __typename: 'ContractOutput';
-                        balanceRoot: string;
-                        inputIndex: string;
-                        stateRoot: string;
-                      }
-                    | {
-                        __typename: 'VariableOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                  >;
-                  policies?: {
-                    __typename: 'Policies';
-                    maturity?: string | null;
-                    maxFee?: string | null;
-                    tip?: string | null;
-                    witnessLimit?: string | null;
-                  } | null;
-                  status?:
-                    | {
-                        __typename: 'FailureStatus';
-                        reason: string;
-                        time: string;
-                        totalFee: string;
-                        totalGas: string;
-                        transactionId: string;
-                      }
-                    | { __typename: 'SqueezedOutStatus'; reason: string }
-                    | { __typename: 'SubmittedStatus'; time: string }
-                    | {
-                        __typename: 'SuccessStatus';
-                        time: string;
-                        totalFee: string;
-                        totalGas: string;
-                        transactionId: string;
-                      }
-                    | null;
-                  upgradePurpose?:
-                    | {
-                        __typename: 'ConsensusParametersPurpose';
-                        checksum: string;
-                        witnessIndex: string;
-                      }
-                    | { __typename: 'StateTransitionPurpose'; root: string }
-                    | null;
-                }>;
-              };
-              programState?: {
-                __typename: 'ProgramState';
-                data: string;
-                returnType: GQLReturnType;
-              } | null;
-              receipts: Array<{
-                __typename: 'Receipt';
-                amount?: string | null;
-                assetId?: string | null;
-                contractId?: string | null;
-                data?: string | null;
-                digest?: string | null;
-                gas?: string | null;
-                gasUsed?: string | null;
-                id?: string | null;
-                is?: string | null;
-                len?: string | null;
-                nonce?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                pc?: string | null;
-                ptr?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                reason?: string | null;
-                receiptType: GQLReceiptType;
-                recipient?: string | null;
-                result?: string | null;
-                sender?: string | null;
-                subId?: string | null;
-                to?: string | null;
-                toAddress?: string | null;
-                val?: string | null;
-              }>;
-            }
-          | null;
-        upgradePurpose?:
-          | {
-              __typename: 'ConsensusParametersPurpose';
-              checksum: string;
-              witnessIndex: string;
-            }
-          | { __typename: 'StateTransitionPurpose'; root: string }
-          | null;
-      }>;
-    };
-  };
-};
+export type GQLChainQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GQLChainQuery = { __typename: 'Query', chain: { __typename: 'ChainInfo', daHeight: string, name: string, consensusParameters: { __typename: 'ConsensusParameters', baseAssetId: string, blockGasLimit: string, chainId: string, privilegedAddress: string, contractParams: { __typename: 'ContractParameters', contractMaxSize: string, maxStorageSlots: string }, feeParams: { __typename: 'FeeParameters', gasPerByte: string, gasPriceFactor: string }, gasCosts: { __typename: 'GasCosts', add: string, addi: string, aloc: string, and: string, andi: string, bal: string, bhei: string, bhsh: string, burn: string, cb: string, cfei: string, cfsi: string, div: string, divi: string, eck1: string, ecr1: string, ed19: string, eq: string, exp: string, expi: string, flag: string, gm: string, gt: string, gtf: string, ji: string, jmp: string, jmpb: string, jmpf: string, jne: string, jneb: string, jnef: string, jnei: string, jnzb: string, jnzf: string, jnzi: string, lb: string, log: string, lt: string, lw: string, mint: string, mldv: string, mlog: string, modOp: string, modi: string, moveOp: string, movi: string, mroo: string, mul: string, muli: string, newStoragePerByte: string, noop: string, not: string, or: string, ori: string, poph: string, popl: string, pshh: string, pshl: string, ret: string, rvrt: string, sb: string, sll: string, slli: string, srl: string, srli: string, srw: string, sub: string, subi: string, sw: string, sww: string, time: string, tr: string, tro: string, wdam: string, wdcm: string, wddv: string, wdmd: string, wdml: string, wdmm: string, wdop: string, wqam: string, wqcm: string, wqdv: string, wqmd: string, wqml: string, wqmm: string, wqop: string, xor: string, xori: string, call: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ccp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, contractRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, croo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, csiz: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, k256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ldc: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, logd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcl: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcli: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcpi: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, meq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, retd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, s256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, scwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, smo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, srwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, stateRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, swwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, vmInitialization: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string } }, predicateParams: { __typename: 'PredicateParameters', maxGasPerPredicate: string, maxMessageDataLength: string, maxPredicateDataLength: string, maxPredicateLength: string }, scriptParams: { __typename: 'ScriptParameters', maxScriptDataLength: string, maxScriptLength: string }, txParams: { __typename: 'TxParameters', maxBytecodeSubsections: string, maxGasPerTx: string, maxInputs: string, maxOutputs: string, maxSize: string, maxWitnesses: string } }, gasCosts: { __typename: 'GasCosts', add: string, addi: string, aloc: string, and: string, andi: string, bal: string, bhei: string, bhsh: string, burn: string, cb: string, cfei: string, cfsi: string, div: string, divi: string, eck1: string, ecr1: string, ed19: string, eq: string, exp: string, expi: string, flag: string, gm: string, gt: string, gtf: string, ji: string, jmp: string, jmpb: string, jmpf: string, jne: string, jneb: string, jnef: string, jnei: string, jnzb: string, jnzf: string, jnzi: string, lb: string, log: string, lt: string, lw: string, mint: string, mldv: string, mlog: string, modOp: string, modi: string, moveOp: string, movi: string, mroo: string, mul: string, muli: string, newStoragePerByte: string, noop: string, not: string, or: string, ori: string, poph: string, popl: string, pshh: string, pshl: string, ret: string, rvrt: string, sb: string, sll: string, slli: string, srl: string, srli: string, srw: string, sub: string, subi: string, sw: string, sww: string, time: string, tr: string, tro: string, wdam: string, wdcm: string, wddv: string, wdmd: string, wdml: string, wdmm: string, wdop: string, wqam: string, wqcm: string, wqdv: string, wqmd: string, wqml: string, wqmm: string, wqop: string, xor: string, xori: string, call: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ccp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, contractRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, croo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, csiz: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, k256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ldc: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, logd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcl: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcli: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcpi: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, meq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, retd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, s256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, scwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, smo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, srwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, stateRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, swwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, vmInitialization: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string } }, latestBlock: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> } } };
 
 export type GQLCoinsQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -3384,87 +1485,27 @@ export type GQLCoinsQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLCoinsQuery = {
-  __typename: 'Query';
-  coins: {
-    __typename: 'CoinConnection';
-    edges: Array<{
-      __typename: 'CoinEdge';
-      cursor: string;
-      node: {
-        __typename: 'Coin';
-        amount: string;
-        assetId: string;
-        blockCreated: string;
-        owner: string;
-        txCreatedIdx: string;
-        utxoId: string;
-      };
-    }>;
-    nodes: Array<{
-      __typename: 'Coin';
-      amount: string;
-      assetId: string;
-      blockCreated: string;
-      owner: string;
-      txCreatedIdx: string;
-      utxoId: string;
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      endCursor?: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-    };
-  };
-};
+
+export type GQLCoinsQuery = { __typename: 'Query', coins: { __typename: 'CoinConnection', edges: Array<{ __typename: 'CoinEdge', cursor: string, node: { __typename: 'Coin', amount: string, assetId: string, blockCreated: string, owner: string, txCreatedIdx: string, utxoId: string } }>, nodes: Array<{ __typename: 'Coin', amount: string, assetId: string, blockCreated: string, owner: string, txCreatedIdx: string, utxoId: string }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type GQLContractQueryVariables = Exact<{
   id: Scalars['ContractId']['input'];
 }>;
 
-export type GQLContractQuery = {
-  __typename: 'Query';
-  contract?: { __typename: 'Contract'; id: string; bytecode: string } | null;
-};
+
+export type GQLContractQuery = { __typename: 'Query', contract?: { __typename: 'Contract', id: string, bytecode: string } | null };
 
 export type GQLContractBalanceQueryVariables = Exact<{
   asset: Scalars['AssetId']['input'];
   contract: Scalars['ContractId']['input'];
 }>;
 
-export type GQLContractBalanceQuery = {
-  __typename: 'Query';
-  contractBalance: {
-    __typename: 'ContractBalance';
-    amount: string;
-    assetId: string;
-    contract: string;
-  };
-};
 
-export type GQLContractBalanceNodeFragment = {
-  __typename: 'ContractBalance';
-  amount: string;
-  assetId: string;
-};
+export type GQLContractBalanceQuery = { __typename: 'Query', contractBalance: { __typename: 'ContractBalance', amount: string, assetId: string, contract: string } };
 
-export type GQLContractBalanceConnectionNodeFragment = {
-  __typename: 'ContractBalanceConnection';
-  edges: Array<{
-    __typename: 'ContractBalanceEdge';
-    cursor: string;
-    node: { __typename: 'ContractBalance'; amount: string; assetId: string };
-  }>;
-  pageInfo: {
-    __typename: 'PageInfo';
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
-    endCursor?: string | null;
-    startCursor?: string | null;
-  };
-};
+export type GQLContractBalanceNodeFragment = { __typename: 'ContractBalance', amount: string, assetId: string };
+
+export type GQLContractBalanceConnectionNodeFragment = { __typename: 'ContractBalanceConnection', edges: Array<{ __typename: 'ContractBalanceEdge', cursor: string, node: { __typename: 'ContractBalance', amount: string, assetId: string } }>, pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null, startCursor?: string | null } };
 
 export type GQLContractBalancesQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -3474,47 +1515,13 @@ export type GQLContractBalancesQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLContractBalancesQuery = {
-  __typename: 'Query';
-  contractBalances: {
-    __typename: 'ContractBalanceConnection';
-    edges: Array<{
-      __typename: 'ContractBalanceEdge';
-      cursor: string;
-      node: { __typename: 'ContractBalance'; amount: string; assetId: string };
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      endCursor?: string | null;
-      startCursor?: string | null;
-    };
-  };
-};
 
-export type GQLNodeInfoQueryVariables = Exact<{ [key: string]: never }>;
+export type GQLContractBalancesQuery = { __typename: 'Query', contractBalances: { __typename: 'ContractBalanceConnection', edges: Array<{ __typename: 'ContractBalanceEdge', cursor: string, node: { __typename: 'ContractBalance', amount: string, assetId: string } }>, pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null, startCursor?: string | null } } };
 
-export type GQLNodeInfoQuery = {
-  __typename: 'Query';
-  nodeInfo: {
-    __typename: 'NodeInfo';
-    maxDepth: string;
-    maxTx: string;
-    nodeVersion: string;
-    utxoValidation: boolean;
-    vmBacktrace: boolean;
-    peers: Array<{
-      __typename: 'PeerInfo';
-      addresses: Array<string>;
-      appScore: number;
-      blockHeight?: string | null;
-      clientVersion?: string | null;
-      id: string;
-      lastHeartbeatMs: string;
-    }>;
-  };
-};
+export type GQLNodeInfoQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GQLNodeInfoQuery = { __typename: 'Query', nodeInfo: { __typename: 'NodeInfo', maxDepth: string, maxTx: string, nodeVersion: string, utxoValidation: boolean, vmBacktrace: boolean, peers: Array<{ __typename: 'PeerInfo', addresses: Array<string>, appScore: number, blockHeight?: string | null, clientVersion?: string | null, id: string, lastHeartbeatMs: string }> } };
 
 export const BalanceItemFragmentDoc = gql`
     fragment BalanceItem on Balance {
@@ -5245,19 +3252,10 @@ export const NodeInfoDocument = gql`
 }
     `;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string,
-  variables?: any,
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType,
-  _variables,
-) => action();
+
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
 const BalanceDocumentString = print(BalanceDocument);
 const BalancesDocumentString = print(BalancesDocument);
 const BlocksDocumentString = print(BlocksDocument);
@@ -5267,205 +3265,35 @@ const ContractDocumentString = print(ContractDocument);
 const ContractBalanceDocumentString = print(ContractBalanceDocument);
 const ContractBalancesDocumentString = print(ContractBalancesDocument);
 const NodeInfoDocumentString = print(NodeInfoDocument);
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper,
-) {
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    balance(
-      variables: GQLBalanceQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLBalanceQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLBalanceQuery>(BalanceDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'balance',
-        'query',
-        variables,
-      );
+    balance(variables: GQLBalanceQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBalanceQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBalanceQuery>(BalanceDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'balance', 'query', variables);
     },
-    balances(
-      variables: GQLBalancesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLBalancesQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLBalancesQuery>(
-            BalancesDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'balances',
-        'query',
-        variables,
-      );
+    balances(variables: GQLBalancesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBalancesQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBalancesQuery>(BalancesDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'balances', 'query', variables);
     },
-    blocks(
-      variables?: GQLBlocksQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLBlocksQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLBlocksQuery>(BlocksDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'blocks',
-        'query',
-        variables,
-      );
+    blocks(variables?: GQLBlocksQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBlocksQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBlocksQuery>(BlocksDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'blocks', 'query', variables);
     },
-    chain(
-      variables?: GQLChainQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLChainQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLChainQuery>(ChainDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'chain',
-        'query',
-        variables,
-      );
+    chain(variables?: GQLChainQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLChainQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLChainQuery>(ChainDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'chain', 'query', variables);
     },
-    coins(
-      variables: GQLCoinsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLCoinsQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLCoinsQuery>(CoinsDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'coins',
-        'query',
-        variables,
-      );
+    coins(variables: GQLCoinsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLCoinsQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLCoinsQuery>(CoinsDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'coins', 'query', variables);
     },
-    contract(
-      variables: GQLContractQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLContractQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLContractQuery>(
-            ContractDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'contract',
-        'query',
-        variables,
-      );
+    contract(variables: GQLContractQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLContractQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLContractQuery>(ContractDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'contract', 'query', variables);
     },
-    contractBalance(
-      variables: GQLContractBalanceQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLContractBalanceQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLContractBalanceQuery>(
-            ContractBalanceDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'contractBalance',
-        'query',
-        variables,
-      );
+    contractBalance(variables: GQLContractBalanceQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLContractBalanceQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLContractBalanceQuery>(ContractBalanceDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'contractBalance', 'query', variables);
     },
-    contractBalances(
-      variables: GQLContractBalancesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLContractBalancesQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLContractBalancesQuery>(
-            ContractBalancesDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'contractBalances',
-        'query',
-        variables,
-      );
+    contractBalances(variables: GQLContractBalancesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLContractBalancesQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLContractBalancesQuery>(ContractBalancesDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'contractBalances', 'query', variables);
     },
-    nodeInfo(
-      variables?: GQLNodeInfoQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLNodeInfoQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLNodeInfoQuery>(
-            NodeInfoDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'nodeInfo',
-        'query',
-        variables,
-      );
-    },
+    nodeInfo(variables?: GQLNodeInfoQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLNodeInfoQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLNodeInfoQuery>(NodeInfoDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'nodeInfo', 'query', variables);
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/graphql/src/graphql/generated/sdk.ts
+++ b/packages/graphql/src/graphql/generated/sdk.ts
@@ -1,51 +1,38 @@
-import { GraphQLError, print } from 'graphql';
 import type { GraphQLClient, RequestOptions } from 'graphql-request';
+import { GraphQLError, print } from 'graphql'
 import gql from 'graphql-tag';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = {
-  [K in keyof T]: T[K];
-};
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]?: Maybe<T[SubKey]>;
-};
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
-  [SubKey in K]: Maybe<T[SubKey]>;
-};
-export type MakeEmpty<
-  T extends { [key: string]: unknown },
-  K extends keyof T,
-> = { [_ in K]?: never };
-export type Incremental<T> =
-  | T
-  | {
-      [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never;
-    };
+export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = { [_ in K]?: never };
+export type Incremental<T> = T | { [P in keyof T]?: P extends ' $fragmentName' | '__typename' ? T[P] : never };
 type GraphQLClientRequestHeaders = RequestOptions['requestHeaders'];
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
-  ID: { input: string; output: string };
-  String: { input: string; output: string };
-  Boolean: { input: boolean; output: boolean };
-  Int: { input: number; output: number };
-  Float: { input: number; output: number };
-  Address: { input: string; output: string };
-  AssetId: { input: string; output: string };
-  BlockId: { input: string; output: string };
-  Bytes32: { input: string; output: string };
-  ContractId: { input: string; output: string };
-  HexString: { input: string; output: string };
-  Nonce: { input: string; output: string };
-  RelayedTransactionId: { input: string; output: string };
-  Salt: { input: string; output: string };
-  Signature: { input: string; output: string };
-  Tai64Timestamp: { input: string; output: string };
-  TransactionId: { input: string; output: string };
-  TxPointer: { input: string; output: string };
-  U16: { input: string; output: string };
-  U32: { input: string; output: string };
-  U64: { input: string; output: string };
-  UtxoId: { input: string; output: string };
+  ID: { input: string; output: string; }
+  String: { input: string; output: string; }
+  Boolean: { input: boolean; output: boolean; }
+  Int: { input: number; output: number; }
+  Float: { input: number; output: number; }
+  Address: { input: string; output: string; }
+  AssetId: { input: string; output: string; }
+  BlockId: { input: string; output: string; }
+  Bytes32: { input: string; output: string; }
+  ContractId: { input: string; output: string; }
+  HexString: { input: string; output: string; }
+  Nonce: { input: string; output: string; }
+  RelayedTransactionId: { input: string; output: string; }
+  Salt: { input: string; output: string; }
+  Signature: { input: string; output: string; }
+  Tai64Timestamp: { input: string; output: string; }
+  TransactionId: { input: string; output: string; }
+  TxPointer: { input: string; output: string; }
+  U16: { input: string; output: string; }
+  U32: { input: string; output: string; }
+  U64: { input: string; output: string; }
+  UtxoId: { input: string; output: string; }
 };
 
 export type GQLBalance = {
@@ -114,7 +101,7 @@ export type GQLBlockEdge = {
 };
 
 export enum GQLBlockVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 /** Breakpoint, defined as a tuple of contract ID and relative PC offset inside it */
@@ -211,7 +198,7 @@ export type GQLConsensusParametersPurpose = {
 };
 
 export enum GQLConsensusParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLContract = {
@@ -280,7 +267,7 @@ export type GQLContractParameters = {
 };
 
 export enum GQLContractParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLDependentCost = GQLHeavyOperation | GQLLightOperation;
@@ -309,9 +296,7 @@ export type GQLDryRunTransactionExecutionStatus = {
   status: GQLDryRunTransactionStatus;
 };
 
-export type GQLDryRunTransactionStatus =
-  | GQLDryRunFailureStatus
-  | GQLDryRunSuccessStatus;
+export type GQLDryRunTransactionStatus = GQLDryRunFailureStatus | GQLDryRunSuccessStatus;
 
 export type GQLEstimateGasPrice = {
   __typename: 'EstimateGasPrice';
@@ -345,7 +330,7 @@ export type GQLFeeParameters = {
 };
 
 export enum GQLFeeParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLGasCosts = {
@@ -465,7 +450,7 @@ export type GQLGasCosts = {
 };
 
 export enum GQLGasCostsVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLGenesis = {
@@ -485,10 +470,7 @@ export type GQLGenesis = {
   transactionsRoot: Scalars['Bytes32']['output'];
 };
 
-export type GQLGroupedInput =
-  | GQLGroupedInputCoin
-  | GQLGroupedInputContract
-  | GQLGroupedInputMessage;
+export type GQLGroupedInput = GQLGroupedInputCoin | GQLGroupedInputContract | GQLGroupedInputMessage;
 
 export type GQLGroupedInputCoin = {
   __typename: 'GroupedInputCoin';
@@ -518,13 +500,10 @@ export type GQLGroupedInputMessage = {
 export enum GQLGroupedInputType {
   InputCoin = 'InputCoin',
   InputContract = 'InputContract',
-  InputMessage = 'InputMessage',
+  InputMessage = 'InputMessage'
 }
 
-export type GQLGroupedOutput =
-  | GQLGroupedOutputChanged
-  | GQLGroupedOutputCoin
-  | GQLGroupedOutputContractCreated;
+export type GQLGroupedOutput = GQLGroupedOutputChanged | GQLGroupedOutputCoin | GQLGroupedOutputContractCreated;
 
 export type GQLGroupedOutputChanged = {
   __typename: 'GroupedOutputChanged';
@@ -554,7 +533,7 @@ export type GQLGroupedOutputContractCreated = {
 export enum GQLGroupedOutputType {
   OutputChanged = 'OutputChanged',
   OutputCoin = 'OutputCoin',
-  OutputContractCreated = 'OutputContractCreated',
+  OutputContractCreated = 'OutputContractCreated'
 }
 
 export type GQLHeader = {
@@ -590,7 +569,7 @@ export type GQLHeader = {
 };
 
 export enum GQLHeaderVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLHeavyOperation = {
@@ -709,7 +688,7 @@ export type GQLMessageProof = {
 export enum GQLMessageState {
   NotFound = 'NOT_FOUND',
   Spent = 'SPENT',
-  Unspent = 'UNSPENT',
+  Unspent = 'UNSPENT'
 }
 
 export type GQLMessageStatus = {
@@ -763,9 +742,11 @@ export type GQLMutation = {
   submit: GQLTransaction;
 };
 
+
 export type GQLMutationContinueTxArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type GQLMutationDryRunArgs = {
   gasPrice?: InputMaybe<Scalars['U64']['input']>;
@@ -773,38 +754,46 @@ export type GQLMutationDryRunArgs = {
   utxoValidation?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
+
 export type GQLMutationEndSessionArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type GQLMutationExecuteArgs = {
   id: Scalars['ID']['input'];
   op: Scalars['String']['input'];
 };
 
+
 export type GQLMutationProduceBlocksArgs = {
   blocksToProduce: Scalars['U32']['input'];
   startTimestamp?: InputMaybe<Scalars['Tai64Timestamp']['input']>;
 };
 
+
 export type GQLMutationResetArgs = {
   id: Scalars['ID']['input'];
 };
+
 
 export type GQLMutationSetBreakpointArgs = {
   breakpoint: GQLBreakpoint;
   id: Scalars['ID']['input'];
 };
 
+
 export type GQLMutationSetSingleSteppingArgs = {
   enable: Scalars['Boolean']['input'];
   id: Scalars['ID']['input'];
 };
 
+
 export type GQLMutationStartTxArgs = {
   id: Scalars['ID']['input'];
   txJson: Scalars['String']['input'];
 };
+
 
 export type GQLMutationSubmitArgs = {
   tx: Scalars['HexString']['input'];
@@ -837,19 +826,14 @@ export enum GQLOperationType {
   FinalResult = 'FINAL_RESULT',
   FromAccount = 'FROM_ACCOUNT',
   FromContract = 'FROM_CONTRACT',
-  Rootless = 'ROOTLESS',
+  Rootless = 'ROOTLESS'
 }
 
 export type GQLOperationsFilterInput = {
   transactionHash: Scalars['String']['input'];
 };
 
-export type GQLOutput =
-  | GQLChangeOutput
-  | GQLCoinOutput
-  | GQLContractCreated
-  | GQLContractOutput
-  | GQLVariableOutput;
+export type GQLOutput = GQLChangeOutput | GQLCoinOutput | GQLContractCreated | GQLContractOutput | GQLVariableOutput;
 
 /**
  * A separate `Breakpoint` type to be used as an output, as a single
@@ -928,7 +912,7 @@ export type GQLPredicateParameters = {
 };
 
 export enum GQLPredicateParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLProgramState = {
@@ -989,10 +973,12 @@ export type GQLQuery = {
   transactionsByOwner: GQLTransactionConnection;
 };
 
+
 export type GQLQueryBalanceArgs = {
   assetId: Scalars['AssetId']['input'];
   owner: Scalars['Address']['input'];
 };
+
 
 export type GQLQueryBalancesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1002,10 +988,12 @@ export type GQLQueryBalancesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryBlockArgs = {
   height?: InputMaybe<Scalars['U32']['input']>;
   id?: InputMaybe<Scalars['BlockId']['input']>;
 };
+
 
 export type GQLQueryBlocksArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1014,9 +1002,11 @@ export type GQLQueryBlocksArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryCoinArgs = {
   utxoId: Scalars['UtxoId']['input'];
 };
+
 
 export type GQLQueryCoinsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1026,20 +1016,24 @@ export type GQLQueryCoinsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryCoinsToSpendArgs = {
   excludedIds?: InputMaybe<GQLExcludeInput>;
   owner: Scalars['Address']['input'];
   queryPerAsset: Array<GQLSpendQueryElementInput>;
 };
 
+
 export type GQLQueryContractArgs = {
   id: Scalars['ContractId']['input'];
 };
+
 
 export type GQLQueryContractBalanceArgs = {
   asset: Scalars['AssetId']['input'];
   contract: Scalars['ContractId']['input'];
 };
+
 
 export type GQLQueryContractBalancesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1049,6 +1043,7 @@ export type GQLQueryContractBalancesArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryContractsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -1056,13 +1051,16 @@ export type GQLQueryContractsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryEstimateGasPriceArgs = {
   blockHorizon?: InputMaybe<Scalars['U32']['input']>;
 };
 
+
 export type GQLQueryEstimatePredicatesArgs = {
   tx: Scalars['HexString']['input'];
 };
+
 
 export type GQLQueryMemoryArgs = {
   id: Scalars['ID']['input'];
@@ -1070,9 +1068,11 @@ export type GQLQueryMemoryArgs = {
   start: Scalars['U32']['input'];
 };
 
+
 export type GQLQueryMessageArgs = {
   nonce: Scalars['Nonce']['input'];
 };
+
 
 export type GQLQueryMessageProofArgs = {
   commitBlockHeight?: InputMaybe<Scalars['U32']['input']>;
@@ -1081,9 +1081,11 @@ export type GQLQueryMessageProofArgs = {
   transactionId: Scalars['TransactionId']['input'];
 };
 
+
 export type GQLQueryMessageStatusArgs = {
   nonce: Scalars['Nonce']['input'];
 };
+
 
 export type GQLQueryMessagesArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1093,26 +1095,32 @@ export type GQLQueryMessagesArgs = {
   owner?: InputMaybe<Scalars['Address']['input']>;
 };
 
+
 export type GQLQueryPredicateArgs = {
   address: Scalars['String']['input'];
 };
+
 
 export type GQLQueryRegisterArgs = {
   id: Scalars['ID']['input'];
   register: Scalars['U32']['input'];
 };
 
+
 export type GQLQueryRelayedTransactionStatusArgs = {
   id: Scalars['RelayedTransactionId']['input'];
 };
+
 
 export type GQLQuerySearchArgs = {
   query: Scalars['String']['input'];
 };
 
+
 export type GQLQueryTransactionArgs = {
   id: Scalars['TransactionId']['input'];
 };
+
 
 export type GQLQueryTransactionsArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1121,6 +1129,7 @@ export type GQLQueryTransactionsArgs = {
   last?: InputMaybe<Scalars['Int']['input']>;
 };
 
+
 export type GQLQueryTransactionsByBlockIdArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
   before?: InputMaybe<Scalars['String']['input']>;
@@ -1128,6 +1137,7 @@ export type GQLQueryTransactionsByBlockIdArgs = {
   first?: InputMaybe<Scalars['Int']['input']>;
   last?: InputMaybe<Scalars['Int']['input']>;
 };
+
 
 export type GQLQueryTransactionsByOwnerArgs = {
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1183,7 +1193,7 @@ export enum GQLReceiptType {
   Revert = 'REVERT',
   ScriptResult = 'SCRIPT_RESULT',
   Transfer = 'TRANSFER',
-  TransferOut = 'TRANSFER_OUT',
+  TransferOut = 'TRANSFER_OUT'
 }
 
 export type GQLRelayedTransactionFailed = {
@@ -1197,7 +1207,7 @@ export type GQLRelayedTransactionStatus = GQLRelayedTransactionFailed;
 export enum GQLReturnType {
   Return = 'RETURN',
   ReturnData = 'RETURN_DATA',
-  Revert = 'REVERT',
+  Revert = 'REVERT'
 }
 
 export type GQLRunResult = {
@@ -1211,7 +1221,7 @@ export enum GQLRunState {
   /** Stopped on a breakpoint */
   Breakpoint = 'BREAKPOINT',
   /** All breakpoints have been processed, and the program has terminated */
-  Completed = 'COMPLETED',
+  Completed = 'COMPLETED'
 }
 
 export type GQLScriptParameters = {
@@ -1222,7 +1232,7 @@ export type GQLScriptParameters = {
 };
 
 export enum GQLScriptParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
 export type GQLSearchAccount = {
@@ -1300,9 +1310,11 @@ export type GQLSubscription = {
   submitAndAwait: GQLTransactionStatus;
 };
 
+
 export type GQLSubscriptionStatusChangeArgs = {
   id: Scalars['TransactionId']['input'];
 };
+
 
 export type GQLSubscriptionSubmitAndAwaitArgs = {
   tx: Scalars['HexString']['input'];
@@ -1393,11 +1405,7 @@ export type GQLTransactionGasCosts = {
   gasUsed?: Maybe<Scalars['U64']['output']>;
 };
 
-export type GQLTransactionStatus =
-  | GQLFailureStatus
-  | GQLSqueezedOutStatus
-  | GQLSubmittedStatus
-  | GQLSuccessStatus;
+export type GQLTransactionStatus = GQLFailureStatus | GQLSqueezedOutStatus | GQLSubmittedStatus | GQLSuccessStatus;
 
 export type GQLTxParameters = {
   __typename: 'TxParameters';
@@ -1411,12 +1419,10 @@ export type GQLTxParameters = {
 };
 
 export enum GQLTxParametersVersion {
-  V1 = 'V1',
+  V1 = 'V1'
 }
 
-export type GQLUpgradePurpose =
-  | GQLConsensusParametersPurpose
-  | GQLStateTransitionPurpose;
+export type GQLUpgradePurpose = GQLConsensusParametersPurpose | GQLStateTransitionPurpose;
 
 export type GQLUtxoItem = {
   __typename: 'UtxoItem';
@@ -1433,19 +1439,7 @@ export type GQLVariableOutput = {
   to: Scalars['Address']['output'];
 };
 
-export type GQLBalanceItemFragment = {
-  __typename: 'Balance';
-  amount: string;
-  assetId: string;
-  owner: string;
-  utxos?: Array<{
-    __typename: 'UtxoItem';
-    amount: string;
-    blockCreated?: string | null;
-    txCreatedIdx?: string | null;
-    utxoId: string;
-  } | null> | null;
-};
+export type GQLBalanceItemFragment = { __typename: 'Balance', amount: string, assetId: string, owner: string, utxos?: Array<{ __typename: 'UtxoItem', amount: string, blockCreated?: string | null, txCreatedIdx?: string | null, utxoId: string } | null> | null };
 
 export type GQLBalancesQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1455,133 +1449,20 @@ export type GQLBalancesQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLBalancesQuery = {
-  __typename: 'Query';
-  balances: {
-    __typename: 'BalanceConnection';
-    nodes: Array<{
-      __typename: 'Balance';
-      amount: string;
-      assetId: string;
-      owner: string;
-      utxos?: Array<{
-        __typename: 'UtxoItem';
-        amount: string;
-        blockCreated?: string | null;
-        txCreatedIdx?: string | null;
-        utxoId: string;
-      } | null> | null;
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      endCursor?: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-    };
-  };
-};
 
-export type GQLBlockFragment = {
-  __typename: 'Block';
-  id: string;
-  producer?: string | null;
-  consensus:
-    | { __typename: 'Genesis' }
-    | { __typename: 'PoAConsensus'; signature: string };
-  header: { __typename: 'Header'; transactionsCount: string };
-  time?: {
-    __typename: 'ParsedTime';
-    full?: string | null;
-    fromNow?: string | null;
-    rawUnix?: string | null;
-  } | null;
-  transactions: Array<{
-    __typename: 'Transaction';
-    _id?: string | null;
-    id: string;
-    title: string;
-    statusType?: string | null;
-    time: {
-      __typename: 'ParsedTime';
-      fromNow?: string | null;
-      rawUnix?: string | null;
-    };
-    gasCosts?: {
-      __typename: 'TransactionGasCosts';
-      fee?: string | null;
-    } | null;
-  }>;
-};
+export type GQLBalancesQuery = { __typename: 'Query', balances: { __typename: 'BalanceConnection', nodes: Array<{ __typename: 'Balance', amount: string, assetId: string, owner: string, utxos?: Array<{ __typename: 'UtxoItem', amount: string, blockCreated?: string | null, txCreatedIdx?: string | null, utxoId: string } | null> | null }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
+
+export type GQLBlockFragment = { __typename: 'Block', id: string, producer?: string | null, consensus: { __typename: 'Genesis' } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', transactionsCount: string }, time?: { __typename: 'ParsedTime', full?: string | null, fromNow?: string | null, rawUnix?: string | null } | null, transactions: Array<{ __typename: 'Transaction', _id?: string | null, id: string, title: string, statusType?: string | null, time: { __typename: 'ParsedTime', fromNow?: string | null, rawUnix?: string | null }, gasCosts?: { __typename: 'TransactionGasCosts', fee?: string | null } | null }> };
 
 export type GQLBlockQueryVariables = Exact<{
   height?: InputMaybe<Scalars['U32']['input']>;
   id?: InputMaybe<Scalars['BlockId']['input']>;
 }>;
 
-export type GQLBlockQuery = {
-  __typename: 'Query';
-  block?: {
-    __typename: 'Block';
-    id: string;
-    producer?: string | null;
-    consensus:
-      | { __typename: 'Genesis' }
-      | { __typename: 'PoAConsensus'; signature: string };
-    header: { __typename: 'Header'; transactionsCount: string };
-    time?: {
-      __typename: 'ParsedTime';
-      full?: string | null;
-      fromNow?: string | null;
-      rawUnix?: string | null;
-    } | null;
-    transactions: Array<{
-      __typename: 'Transaction';
-      _id?: string | null;
-      id: string;
-      title: string;
-      statusType?: string | null;
-      time: {
-        __typename: 'ParsedTime';
-        fromNow?: string | null;
-        rawUnix?: string | null;
-      };
-      gasCosts?: {
-        __typename: 'TransactionGasCosts';
-        fee?: string | null;
-      } | null;
-    }>;
-  } | null;
-};
 
-export type GQLBlockItemFragment = {
-  __typename: 'Block';
-  totalGasUsed?: string | null;
-  producer?: string | null;
-  id: string;
-  time?: {
-    __typename: 'ParsedTime';
-    fromNow?: string | null;
-    full?: string | null;
-    rawTai64?: string | null;
-    rawUnix?: string | null;
-  } | null;
-  consensus:
-    | { __typename: 'Genesis' }
-    | { __typename: 'PoAConsensus'; signature: string };
-  header: {
-    __typename: 'Header';
-    id: string;
-    height: string;
-    time: string;
-    transactionsCount: string;
-  };
-  transactions: Array<{
-    __typename: 'Transaction';
-    isMint: boolean;
-    mintAmount?: string | null;
-  }>;
-};
+export type GQLBlockQuery = { __typename: 'Query', block?: { __typename: 'Block', id: string, producer?: string | null, consensus: { __typename: 'Genesis' } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', transactionsCount: string }, time?: { __typename: 'ParsedTime', full?: string | null, fromNow?: string | null, rawUnix?: string | null } | null, transactions: Array<{ __typename: 'Transaction', _id?: string | null, id: string, title: string, statusType?: string | null, time: { __typename: 'ParsedTime', fromNow?: string | null, rawUnix?: string | null }, gasCosts?: { __typename: 'TransactionGasCosts', fee?: string | null } | null }> } | null };
+
+export type GQLBlockItemFragment = { __typename: 'Block', totalGasUsed?: string | null, producer?: string | null, id: string, time?: { __typename: 'ParsedTime', fromNow?: string | null, full?: string | null, rawTai64?: string | null, rawUnix?: string | null } | null, consensus: { __typename: 'Genesis' } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', id: string, height: string, time: string, transactionsCount: string }, transactions: Array<{ __typename: 'Transaction', isMint: boolean, mintAmount?: string | null }> };
 
 export type GQLBlocksQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -1590,1000 +1471,13 @@ export type GQLBlocksQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLBlocksQuery = {
-  __typename: 'Query';
-  blocks: {
-    __typename: 'BlockConnection';
-    pageInfo: {
-      __typename: 'PageInfo';
-      startCursor?: string | null;
-      endCursor?: string | null;
-      hasPreviousPage: boolean;
-      hasNextPage: boolean;
-    };
-    edges: Array<{
-      __typename: 'BlockEdge';
-      node: {
-        __typename: 'Block';
-        totalGasUsed?: string | null;
-        producer?: string | null;
-        id: string;
-        time?: {
-          __typename: 'ParsedTime';
-          fromNow?: string | null;
-          full?: string | null;
-          rawTai64?: string | null;
-          rawUnix?: string | null;
-        } | null;
-        consensus:
-          | { __typename: 'Genesis' }
-          | { __typename: 'PoAConsensus'; signature: string };
-        header: {
-          __typename: 'Header';
-          id: string;
-          height: string;
-          time: string;
-          transactionsCount: string;
-        };
-        transactions: Array<{
-          __typename: 'Transaction';
-          isMint: boolean;
-          mintAmount?: string | null;
-        }>;
-      };
-    }>;
-  };
-};
 
-export type GQLChainQueryVariables = Exact<{ [key: string]: never }>;
+export type GQLBlocksQuery = { __typename: 'Query', blocks: { __typename: 'BlockConnection', pageInfo: { __typename: 'PageInfo', startCursor?: string | null, endCursor?: string | null, hasPreviousPage: boolean, hasNextPage: boolean }, edges: Array<{ __typename: 'BlockEdge', node: { __typename: 'Block', totalGasUsed?: string | null, producer?: string | null, id: string, time?: { __typename: 'ParsedTime', fromNow?: string | null, full?: string | null, rawTai64?: string | null, rawUnix?: string | null } | null, consensus: { __typename: 'Genesis' } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', id: string, height: string, time: string, transactionsCount: string }, transactions: Array<{ __typename: 'Transaction', isMint: boolean, mintAmount?: string | null }> } }> } };
 
-export type GQLChainQuery = {
-  __typename: 'Query';
-  chain: {
-    __typename: 'ChainInfo';
-    daHeight: string;
-    name: string;
-    consensusParameters: {
-      __typename: 'ConsensusParameters';
-      baseAssetId: string;
-      blockGasLimit: string;
-      chainId: string;
-      privilegedAddress: string;
-      contractParams: {
-        __typename: 'ContractParameters';
-        contractMaxSize: string;
-        maxStorageSlots: string;
-      };
-      feeParams: {
-        __typename: 'FeeParameters';
-        gasPerByte: string;
-        gasPriceFactor: string;
-      };
-      gasCosts: {
-        __typename: 'GasCosts';
-        add: string;
-        addi: string;
-        aloc: string;
-        and: string;
-        andi: string;
-        bal: string;
-        bhei: string;
-        bhsh: string;
-        burn: string;
-        cb: string;
-        cfei: string;
-        cfsi: string;
-        div: string;
-        divi: string;
-        eck1: string;
-        ecr1: string;
-        ed19: string;
-        eq: string;
-        exp: string;
-        expi: string;
-        flag: string;
-        gm: string;
-        gt: string;
-        gtf: string;
-        ji: string;
-        jmp: string;
-        jmpb: string;
-        jmpf: string;
-        jne: string;
-        jneb: string;
-        jnef: string;
-        jnei: string;
-        jnzb: string;
-        jnzf: string;
-        jnzi: string;
-        lb: string;
-        log: string;
-        lt: string;
-        lw: string;
-        mint: string;
-        mldv: string;
-        mlog: string;
-        modOp: string;
-        modi: string;
-        moveOp: string;
-        movi: string;
-        mroo: string;
-        mul: string;
-        muli: string;
-        newStoragePerByte: string;
-        noop: string;
-        not: string;
-        or: string;
-        ori: string;
-        poph: string;
-        popl: string;
-        pshh: string;
-        pshl: string;
-        ret: string;
-        rvrt: string;
-        sb: string;
-        sll: string;
-        slli: string;
-        srl: string;
-        srli: string;
-        srw: string;
-        sub: string;
-        subi: string;
-        sw: string;
-        sww: string;
-        time: string;
-        tr: string;
-        tro: string;
-        wdam: string;
-        wdcm: string;
-        wddv: string;
-        wdmd: string;
-        wdml: string;
-        wdmm: string;
-        wdop: string;
-        wqam: string;
-        wqcm: string;
-        wqdv: string;
-        wqmd: string;
-        wqml: string;
-        wqmm: string;
-        wqop: string;
-        xor: string;
-        xori: string;
-        call:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        ccp:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        contractRoot:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        croo:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        csiz:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        k256:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        ldc:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        logd:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        mcl:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        mcli:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        mcp:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        mcpi:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        meq:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        retd:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        s256:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        scwq:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        smo:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        srwq:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        stateRoot:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        swwq:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-        vmInitialization:
-          | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-          | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      };
-      predicateParams: {
-        __typename: 'PredicateParameters';
-        maxGasPerPredicate: string;
-        maxMessageDataLength: string;
-        maxPredicateDataLength: string;
-        maxPredicateLength: string;
-      };
-      scriptParams: {
-        __typename: 'ScriptParameters';
-        maxScriptDataLength: string;
-        maxScriptLength: string;
-      };
-      txParams: {
-        __typename: 'TxParameters';
-        maxBytecodeSubsections: string;
-        maxGasPerTx: string;
-        maxInputs: string;
-        maxOutputs: string;
-        maxSize: string;
-        maxWitnesses: string;
-      };
-    };
-    gasCosts: {
-      __typename: 'GasCosts';
-      add: string;
-      addi: string;
-      aloc: string;
-      and: string;
-      andi: string;
-      bal: string;
-      bhei: string;
-      bhsh: string;
-      burn: string;
-      cb: string;
-      cfei: string;
-      cfsi: string;
-      div: string;
-      divi: string;
-      eck1: string;
-      ecr1: string;
-      ed19: string;
-      eq: string;
-      exp: string;
-      expi: string;
-      flag: string;
-      gm: string;
-      gt: string;
-      gtf: string;
-      ji: string;
-      jmp: string;
-      jmpb: string;
-      jmpf: string;
-      jne: string;
-      jneb: string;
-      jnef: string;
-      jnei: string;
-      jnzb: string;
-      jnzf: string;
-      jnzi: string;
-      lb: string;
-      log: string;
-      lt: string;
-      lw: string;
-      mint: string;
-      mldv: string;
-      mlog: string;
-      modOp: string;
-      modi: string;
-      moveOp: string;
-      movi: string;
-      mroo: string;
-      mul: string;
-      muli: string;
-      newStoragePerByte: string;
-      noop: string;
-      not: string;
-      or: string;
-      ori: string;
-      poph: string;
-      popl: string;
-      pshh: string;
-      pshl: string;
-      ret: string;
-      rvrt: string;
-      sb: string;
-      sll: string;
-      slli: string;
-      srl: string;
-      srli: string;
-      srw: string;
-      sub: string;
-      subi: string;
-      sw: string;
-      sww: string;
-      time: string;
-      tr: string;
-      tro: string;
-      wdam: string;
-      wdcm: string;
-      wddv: string;
-      wdmd: string;
-      wdml: string;
-      wdmm: string;
-      wdop: string;
-      wqam: string;
-      wqcm: string;
-      wqdv: string;
-      wqmd: string;
-      wqml: string;
-      wqmm: string;
-      wqop: string;
-      xor: string;
-      xori: string;
-      call:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      ccp:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      contractRoot:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      croo:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      csiz:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      k256:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      ldc:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      logd:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      mcl:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      mcli:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      mcp:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      mcpi:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      meq:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      retd:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      s256:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      scwq:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      smo:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      srwq:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      stateRoot:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      swwq:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-      vmInitialization:
-        | { __typename: 'HeavyOperation'; base: string; gasPerUnit: string }
-        | { __typename: 'LightOperation'; base: string; unitsPerGas: string };
-    };
-    latestBlock: {
-      __typename: 'Block';
-      height: string;
-      id: string;
-      consensus:
-        | {
-            __typename: 'Genesis';
-            chainConfigHash: string;
-            coinsRoot: string;
-            contractsRoot: string;
-            messagesRoot: string;
-            transactionsRoot: string;
-          }
-        | { __typename: 'PoAConsensus'; signature: string };
-      header: {
-        __typename: 'Header';
-        applicationHash: string;
-        consensusParametersVersion: string;
-        daHeight: string;
-        eventInboxRoot: string;
-        height: string;
-        id: string;
-        messageOutboxRoot: string;
-        messageReceiptCount: string;
-        prevRoot: string;
-        stateTransitionBytecodeVersion: string;
-        time: string;
-        transactionsCount: string;
-        transactionsRoot: string;
-      };
-      transactions: Array<{
-        __typename: 'Transaction';
-        bytecodeRoot?: string | null;
-        bytecodeWitnessIndex?: string | null;
-        id: string;
-        inputAssetIds?: Array<string> | null;
-        inputContracts?: Array<string> | null;
-        isCreate: boolean;
-        isMint: boolean;
-        isScript: boolean;
-        isUpgrade: boolean;
-        isUpload: boolean;
-        maturity?: string | null;
-        mintAmount?: string | null;
-        mintAssetId?: string | null;
-        mintGasPrice?: string | null;
-        proofSet?: Array<string> | null;
-        rawPayload: string;
-        receiptsRoot?: string | null;
-        salt?: string | null;
-        script?: string | null;
-        scriptData?: string | null;
-        scriptGasLimit?: string | null;
-        storageSlots?: Array<string> | null;
-        subsectionIndex?: string | null;
-        subsectionsNumber?: string | null;
-        txPointer?: string | null;
-        witnesses?: Array<string> | null;
-        inputContract?: {
-          __typename: 'InputContract';
-          balanceRoot: string;
-          contractId: string;
-          stateRoot: string;
-          txPointer: string;
-          utxoId: string;
-        } | null;
-        inputs?: Array<
-          | {
-              __typename: 'InputCoin';
-              amount: string;
-              assetId: string;
-              owner: string;
-              predicate: string;
-              predicateData: string;
-              predicateGasUsed: string;
-              txPointer: string;
-              utxoId: string;
-              witnessIndex: string;
-            }
-          | {
-              __typename: 'InputContract';
-              balanceRoot: string;
-              contractId: string;
-              stateRoot: string;
-              txPointer: string;
-              utxoId: string;
-            }
-          | {
-              __typename: 'InputMessage';
-              amount: string;
-              data: string;
-              nonce: string;
-              predicate: string;
-              predicateData: string;
-              predicateGasUsed: string;
-              recipient: string;
-              sender: string;
-              witnessIndex: string;
-            }
-        > | null;
-        outputContract?: {
-          __typename: 'ContractOutput';
-          balanceRoot: string;
-          inputIndex: string;
-          stateRoot: string;
-        } | null;
-        outputs: Array<
-          | {
-              __typename: 'ChangeOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-          | {
-              __typename: 'CoinOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-          | {
-              __typename: 'ContractCreated';
-              contract: string;
-              stateRoot: string;
-            }
-          | {
-              __typename: 'ContractOutput';
-              balanceRoot: string;
-              inputIndex: string;
-              stateRoot: string;
-            }
-          | {
-              __typename: 'VariableOutput';
-              amount: string;
-              assetId: string;
-              to: string;
-            }
-        >;
-        policies?: {
-          __typename: 'Policies';
-          maturity?: string | null;
-          maxFee?: string | null;
-          tip?: string | null;
-          witnessLimit?: string | null;
-        } | null;
-        status?:
-          | {
-              __typename: 'FailureStatus';
-              reason: string;
-              time: string;
-              totalFee: string;
-              totalGas: string;
-              transactionId: string;
-              block: {
-                __typename: 'Block';
-                height: string;
-                id: string;
-                consensus:
-                  | {
-                      __typename: 'Genesis';
-                      chainConfigHash: string;
-                      coinsRoot: string;
-                      contractsRoot: string;
-                      messagesRoot: string;
-                      transactionsRoot: string;
-                    }
-                  | { __typename: 'PoAConsensus'; signature: string };
-                header: {
-                  __typename: 'Header';
-                  applicationHash: string;
-                  consensusParametersVersion: string;
-                  daHeight: string;
-                  eventInboxRoot: string;
-                  height: string;
-                  id: string;
-                  messageOutboxRoot: string;
-                  messageReceiptCount: string;
-                  prevRoot: string;
-                  stateTransitionBytecodeVersion: string;
-                  time: string;
-                  transactionsCount: string;
-                  transactionsRoot: string;
-                };
-                transactions: Array<{
-                  __typename: 'Transaction';
-                  bytecodeRoot?: string | null;
-                  bytecodeWitnessIndex?: string | null;
-                  id: string;
-                  inputAssetIds?: Array<string> | null;
-                  inputContracts?: Array<string> | null;
-                  isCreate: boolean;
-                  isMint: boolean;
-                  isScript: boolean;
-                  isUpgrade: boolean;
-                  isUpload: boolean;
-                  maturity?: string | null;
-                  mintAmount?: string | null;
-                  mintAssetId?: string | null;
-                  mintGasPrice?: string | null;
-                  proofSet?: Array<string> | null;
-                  rawPayload: string;
-                  receiptsRoot?: string | null;
-                  salt?: string | null;
-                  script?: string | null;
-                  scriptData?: string | null;
-                  scriptGasLimit?: string | null;
-                  storageSlots?: Array<string> | null;
-                  subsectionIndex?: string | null;
-                  subsectionsNumber?: string | null;
-                  txPointer?: string | null;
-                  witnesses?: Array<string> | null;
-                  inputContract?: {
-                    __typename: 'InputContract';
-                    balanceRoot: string;
-                    contractId: string;
-                    stateRoot: string;
-                    txPointer: string;
-                    utxoId: string;
-                  } | null;
-                  inputs?: Array<
-                    | {
-                        __typename: 'InputCoin';
-                        amount: string;
-                        assetId: string;
-                        owner: string;
-                        predicate: string;
-                        predicateData: string;
-                        predicateGasUsed: string;
-                        txPointer: string;
-                        utxoId: string;
-                        witnessIndex: string;
-                      }
-                    | {
-                        __typename: 'InputContract';
-                        balanceRoot: string;
-                        contractId: string;
-                        stateRoot: string;
-                        txPointer: string;
-                        utxoId: string;
-                      }
-                    | {
-                        __typename: 'InputMessage';
-                        amount: string;
-                        data: string;
-                        nonce: string;
-                        predicate: string;
-                        predicateData: string;
-                        predicateGasUsed: string;
-                        recipient: string;
-                        sender: string;
-                        witnessIndex: string;
-                      }
-                  > | null;
-                  outputContract?: {
-                    __typename: 'ContractOutput';
-                    balanceRoot: string;
-                    inputIndex: string;
-                    stateRoot: string;
-                  } | null;
-                  outputs: Array<
-                    | {
-                        __typename: 'ChangeOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                    | {
-                        __typename: 'CoinOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                    | {
-                        __typename: 'ContractCreated';
-                        contract: string;
-                        stateRoot: string;
-                      }
-                    | {
-                        __typename: 'ContractOutput';
-                        balanceRoot: string;
-                        inputIndex: string;
-                        stateRoot: string;
-                      }
-                    | {
-                        __typename: 'VariableOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                  >;
-                  policies?: {
-                    __typename: 'Policies';
-                    maturity?: string | null;
-                    maxFee?: string | null;
-                    tip?: string | null;
-                    witnessLimit?: string | null;
-                  } | null;
-                  status?:
-                    | {
-                        __typename: 'FailureStatus';
-                        reason: string;
-                        time: string;
-                        totalFee: string;
-                        totalGas: string;
-                        transactionId: string;
-                      }
-                    | { __typename: 'SqueezedOutStatus'; reason: string }
-                    | { __typename: 'SubmittedStatus'; time: string }
-                    | {
-                        __typename: 'SuccessStatus';
-                        time: string;
-                        totalFee: string;
-                        totalGas: string;
-                        transactionId: string;
-                      }
-                    | null;
-                  upgradePurpose?:
-                    | {
-                        __typename: 'ConsensusParametersPurpose';
-                        checksum: string;
-                        witnessIndex: string;
-                      }
-                    | { __typename: 'StateTransitionPurpose'; root: string }
-                    | null;
-                }>;
-              };
-              programState?: {
-                __typename: 'ProgramState';
-                data: string;
-                returnType: GQLReturnType;
-              } | null;
-              receipts: Array<{
-                __typename: 'Receipt';
-                amount?: string | null;
-                assetId?: string | null;
-                contractId?: string | null;
-                data?: string | null;
-                digest?: string | null;
-                gas?: string | null;
-                gasUsed?: string | null;
-                id?: string | null;
-                is?: string | null;
-                len?: string | null;
-                nonce?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                pc?: string | null;
-                ptr?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                reason?: string | null;
-                receiptType: GQLReceiptType;
-                recipient?: string | null;
-                result?: string | null;
-                sender?: string | null;
-                subId?: string | null;
-                to?: string | null;
-                toAddress?: string | null;
-                val?: string | null;
-              }>;
-            }
-          | { __typename: 'SqueezedOutStatus'; reason: string }
-          | { __typename: 'SubmittedStatus'; time: string }
-          | {
-              __typename: 'SuccessStatus';
-              time: string;
-              totalFee: string;
-              totalGas: string;
-              transactionId: string;
-              block: {
-                __typename: 'Block';
-                height: string;
-                id: string;
-                consensus:
-                  | {
-                      __typename: 'Genesis';
-                      chainConfigHash: string;
-                      coinsRoot: string;
-                      contractsRoot: string;
-                      messagesRoot: string;
-                      transactionsRoot: string;
-                    }
-                  | { __typename: 'PoAConsensus'; signature: string };
-                header: {
-                  __typename: 'Header';
-                  applicationHash: string;
-                  consensusParametersVersion: string;
-                  daHeight: string;
-                  eventInboxRoot: string;
-                  height: string;
-                  id: string;
-                  messageOutboxRoot: string;
-                  messageReceiptCount: string;
-                  prevRoot: string;
-                  stateTransitionBytecodeVersion: string;
-                  time: string;
-                  transactionsCount: string;
-                  transactionsRoot: string;
-                };
-                transactions: Array<{
-                  __typename: 'Transaction';
-                  bytecodeRoot?: string | null;
-                  bytecodeWitnessIndex?: string | null;
-                  id: string;
-                  inputAssetIds?: Array<string> | null;
-                  inputContracts?: Array<string> | null;
-                  isCreate: boolean;
-                  isMint: boolean;
-                  isScript: boolean;
-                  isUpgrade: boolean;
-                  isUpload: boolean;
-                  maturity?: string | null;
-                  mintAmount?: string | null;
-                  mintAssetId?: string | null;
-                  mintGasPrice?: string | null;
-                  proofSet?: Array<string> | null;
-                  rawPayload: string;
-                  receiptsRoot?: string | null;
-                  salt?: string | null;
-                  script?: string | null;
-                  scriptData?: string | null;
-                  scriptGasLimit?: string | null;
-                  storageSlots?: Array<string> | null;
-                  subsectionIndex?: string | null;
-                  subsectionsNumber?: string | null;
-                  txPointer?: string | null;
-                  witnesses?: Array<string> | null;
-                  inputContract?: {
-                    __typename: 'InputContract';
-                    balanceRoot: string;
-                    contractId: string;
-                    stateRoot: string;
-                    txPointer: string;
-                    utxoId: string;
-                  } | null;
-                  inputs?: Array<
-                    | {
-                        __typename: 'InputCoin';
-                        amount: string;
-                        assetId: string;
-                        owner: string;
-                        predicate: string;
-                        predicateData: string;
-                        predicateGasUsed: string;
-                        txPointer: string;
-                        utxoId: string;
-                        witnessIndex: string;
-                      }
-                    | {
-                        __typename: 'InputContract';
-                        balanceRoot: string;
-                        contractId: string;
-                        stateRoot: string;
-                        txPointer: string;
-                        utxoId: string;
-                      }
-                    | {
-                        __typename: 'InputMessage';
-                        amount: string;
-                        data: string;
-                        nonce: string;
-                        predicate: string;
-                        predicateData: string;
-                        predicateGasUsed: string;
-                        recipient: string;
-                        sender: string;
-                        witnessIndex: string;
-                      }
-                  > | null;
-                  outputContract?: {
-                    __typename: 'ContractOutput';
-                    balanceRoot: string;
-                    inputIndex: string;
-                    stateRoot: string;
-                  } | null;
-                  outputs: Array<
-                    | {
-                        __typename: 'ChangeOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                    | {
-                        __typename: 'CoinOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                    | {
-                        __typename: 'ContractCreated';
-                        contract: string;
-                        stateRoot: string;
-                      }
-                    | {
-                        __typename: 'ContractOutput';
-                        balanceRoot: string;
-                        inputIndex: string;
-                        stateRoot: string;
-                      }
-                    | {
-                        __typename: 'VariableOutput';
-                        amount: string;
-                        assetId: string;
-                        to: string;
-                      }
-                  >;
-                  policies?: {
-                    __typename: 'Policies';
-                    maturity?: string | null;
-                    maxFee?: string | null;
-                    tip?: string | null;
-                    witnessLimit?: string | null;
-                  } | null;
-                  status?:
-                    | {
-                        __typename: 'FailureStatus';
-                        reason: string;
-                        time: string;
-                        totalFee: string;
-                        totalGas: string;
-                        transactionId: string;
-                      }
-                    | { __typename: 'SqueezedOutStatus'; reason: string }
-                    | { __typename: 'SubmittedStatus'; time: string }
-                    | {
-                        __typename: 'SuccessStatus';
-                        time: string;
-                        totalFee: string;
-                        totalGas: string;
-                        transactionId: string;
-                      }
-                    | null;
-                  upgradePurpose?:
-                    | {
-                        __typename: 'ConsensusParametersPurpose';
-                        checksum: string;
-                        witnessIndex: string;
-                      }
-                    | { __typename: 'StateTransitionPurpose'; root: string }
-                    | null;
-                }>;
-              };
-              programState?: {
-                __typename: 'ProgramState';
-                data: string;
-                returnType: GQLReturnType;
-              } | null;
-              receipts: Array<{
-                __typename: 'Receipt';
-                amount?: string | null;
-                assetId?: string | null;
-                contractId?: string | null;
-                data?: string | null;
-                digest?: string | null;
-                gas?: string | null;
-                gasUsed?: string | null;
-                id?: string | null;
-                is?: string | null;
-                len?: string | null;
-                nonce?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                pc?: string | null;
-                ptr?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                reason?: string | null;
-                receiptType: GQLReceiptType;
-                recipient?: string | null;
-                result?: string | null;
-                sender?: string | null;
-                subId?: string | null;
-                to?: string | null;
-                toAddress?: string | null;
-                val?: string | null;
-              }>;
-            }
-          | null;
-        upgradePurpose?:
-          | {
-              __typename: 'ConsensusParametersPurpose';
-              checksum: string;
-              witnessIndex: string;
-            }
-          | { __typename: 'StateTransitionPurpose'; root: string }
-          | null;
-      }>;
-    };
-  };
-};
+export type GQLChainQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type GQLChainQuery = { __typename: 'Query', chain: { __typename: 'ChainInfo', daHeight: string, name: string, consensusParameters: { __typename: 'ConsensusParameters', baseAssetId: string, blockGasLimit: string, chainId: string, privilegedAddress: string, contractParams: { __typename: 'ContractParameters', contractMaxSize: string, maxStorageSlots: string }, feeParams: { __typename: 'FeeParameters', gasPerByte: string, gasPriceFactor: string }, gasCosts: { __typename: 'GasCosts', add: string, addi: string, aloc: string, and: string, andi: string, bal: string, bhei: string, bhsh: string, burn: string, cb: string, cfei: string, cfsi: string, div: string, divi: string, eck1: string, ecr1: string, ed19: string, eq: string, exp: string, expi: string, flag: string, gm: string, gt: string, gtf: string, ji: string, jmp: string, jmpb: string, jmpf: string, jne: string, jneb: string, jnef: string, jnei: string, jnzb: string, jnzf: string, jnzi: string, lb: string, log: string, lt: string, lw: string, mint: string, mldv: string, mlog: string, modOp: string, modi: string, moveOp: string, movi: string, mroo: string, mul: string, muli: string, newStoragePerByte: string, noop: string, not: string, or: string, ori: string, poph: string, popl: string, pshh: string, pshl: string, ret: string, rvrt: string, sb: string, sll: string, slli: string, srl: string, srli: string, srw: string, sub: string, subi: string, sw: string, sww: string, time: string, tr: string, tro: string, wdam: string, wdcm: string, wddv: string, wdmd: string, wdml: string, wdmm: string, wdop: string, wqam: string, wqcm: string, wqdv: string, wqmd: string, wqml: string, wqmm: string, wqop: string, xor: string, xori: string, call: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ccp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, contractRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, croo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, csiz: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, k256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ldc: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, logd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcl: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcli: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcpi: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, meq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, retd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, s256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, scwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, smo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, srwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, stateRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, swwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, vmInitialization: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string } }, predicateParams: { __typename: 'PredicateParameters', maxGasPerPredicate: string, maxMessageDataLength: string, maxPredicateDataLength: string, maxPredicateLength: string }, scriptParams: { __typename: 'ScriptParameters', maxScriptDataLength: string, maxScriptLength: string }, txParams: { __typename: 'TxParameters', maxBytecodeSubsections: string, maxGasPerTx: string, maxInputs: string, maxOutputs: string, maxSize: string, maxWitnesses: string } }, gasCosts: { __typename: 'GasCosts', add: string, addi: string, aloc: string, and: string, andi: string, bal: string, bhei: string, bhsh: string, burn: string, cb: string, cfei: string, cfsi: string, div: string, divi: string, eck1: string, ecr1: string, ed19: string, eq: string, exp: string, expi: string, flag: string, gm: string, gt: string, gtf: string, ji: string, jmp: string, jmpb: string, jmpf: string, jne: string, jneb: string, jnef: string, jnei: string, jnzb: string, jnzf: string, jnzi: string, lb: string, log: string, lt: string, lw: string, mint: string, mldv: string, mlog: string, modOp: string, modi: string, moveOp: string, movi: string, mroo: string, mul: string, muli: string, newStoragePerByte: string, noop: string, not: string, or: string, ori: string, poph: string, popl: string, pshh: string, pshl: string, ret: string, rvrt: string, sb: string, sll: string, slli: string, srl: string, srli: string, srw: string, sub: string, subi: string, sw: string, sww: string, time: string, tr: string, tro: string, wdam: string, wdcm: string, wddv: string, wdmd: string, wdml: string, wdmm: string, wdop: string, wqam: string, wqcm: string, wqdv: string, wqmd: string, wqml: string, wqmm: string, wqop: string, xor: string, xori: string, call: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ccp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, contractRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, croo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, csiz: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, k256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, ldc: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, logd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcl: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcli: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcp: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, mcpi: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, meq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, retd: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, s256: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, scwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, smo: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, srwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, stateRoot: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, swwq: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string }, vmInitialization: { __typename: 'HeavyOperation', base: string, gasPerUnit: string } | { __typename: 'LightOperation', base: string, unitsPerGas: string } }, latestBlock: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string, block: { __typename: 'Block', height: string, id: string, consensus: { __typename: 'Genesis', chainConfigHash: string, coinsRoot: string, contractsRoot: string, messagesRoot: string, transactionsRoot: string } | { __typename: 'PoAConsensus', signature: string }, header: { __typename: 'Header', applicationHash: string, consensusParametersVersion: string, daHeight: string, eventInboxRoot: string, height: string, id: string, messageOutboxRoot: string, messageReceiptCount: string, prevRoot: string, stateTransitionBytecodeVersion: string, time: string, transactionsCount: string, transactionsRoot: string }, transactions: Array<{ __typename: 'Transaction', bytecodeRoot?: string | null, bytecodeWitnessIndex?: string | null, id: string, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, isCreate: boolean, isMint: boolean, isScript: boolean, isUpgrade: boolean, isUpload: boolean, maturity?: string | null, mintAmount?: string | null, mintAssetId?: string | null, mintGasPrice?: string | null, proofSet?: Array<string> | null, rawPayload: string, receiptsRoot?: string | null, salt?: string | null, script?: string | null, scriptData?: string | null, scriptGasLimit?: string | null, storageSlots?: Array<string> | null, subsectionIndex?: string | null, subsectionsNumber?: string | null, txPointer?: string | null, witnesses?: Array<string> | null, inputContract?: { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, predicateGasUsed: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', balanceRoot: string, contractId: string, stateRoot: string, txPointer: string, utxoId: string } | { __typename: 'InputMessage', amount: string, data: string, nonce: string, predicate: string, predicateData: string, predicateGasUsed: string, recipient: string, sender: string, witnessIndex: string }> | null, outputContract?: { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | null, outputs: Array<{ __typename: 'ChangeOutput', amount: string, assetId: string, to: string } | { __typename: 'CoinOutput', amount: string, assetId: string, to: string } | { __typename: 'ContractCreated', contract: string, stateRoot: string } | { __typename: 'ContractOutput', balanceRoot: string, inputIndex: string, stateRoot: string } | { __typename: 'VariableOutput', amount: string, assetId: string, to: string }>, policies?: { __typename: 'Policies', maturity?: string | null, maxFee?: string | null, tip?: string | null, witnessLimit?: string | null } | null, status?: { __typename: 'FailureStatus', reason: string, time: string, totalFee: string, totalGas: string, transactionId: string } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, totalFee: string, totalGas: string, transactionId: string } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> }, programState?: { __typename: 'ProgramState', data: string, returnType: GQLReturnType } | null, receipts: Array<{ __typename: 'Receipt', amount?: string | null, assetId?: string | null, contractId?: string | null, data?: string | null, digest?: string | null, gas?: string | null, gasUsed?: string | null, id?: string | null, is?: string | null, len?: string | null, nonce?: string | null, param1?: string | null, param2?: string | null, pc?: string | null, ptr?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, reason?: string | null, receiptType: GQLReceiptType, recipient?: string | null, result?: string | null, sender?: string | null, subId?: string | null, to?: string | null, toAddress?: string | null, val?: string | null }> } | null, upgradePurpose?: { __typename: 'ConsensusParametersPurpose', checksum: string, witnessIndex: string } | { __typename: 'StateTransitionPurpose', root: string } | null }> } } };
 
 export type GQLCoinsQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -2593,72 +1487,19 @@ export type GQLCoinsQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLCoinsQuery = {
-  __typename: 'Query';
-  coins: {
-    __typename: 'CoinConnection';
-    edges: Array<{
-      __typename: 'CoinEdge';
-      cursor: string;
-      node: {
-        __typename: 'Coin';
-        amount: string;
-        assetId: string;
-        blockCreated: string;
-        owner: string;
-        txCreatedIdx: string;
-        utxoId: string;
-      };
-    }>;
-    nodes: Array<{
-      __typename: 'Coin';
-      amount: string;
-      assetId: string;
-      blockCreated: string;
-      owner: string;
-      txCreatedIdx: string;
-      utxoId: string;
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      endCursor?: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-    };
-  };
-};
+
+export type GQLCoinsQuery = { __typename: 'Query', coins: { __typename: 'CoinConnection', edges: Array<{ __typename: 'CoinEdge', cursor: string, node: { __typename: 'Coin', amount: string, assetId: string, blockCreated: string, owner: string, txCreatedIdx: string, utxoId: string } }>, nodes: Array<{ __typename: 'Coin', amount: string, assetId: string, blockCreated: string, owner: string, txCreatedIdx: string, utxoId: string }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type GQLContractQueryVariables = Exact<{
   id: Scalars['ContractId']['input'];
 }>;
 
-export type GQLContractQuery = {
-  __typename: 'Query';
-  contract?: { __typename: 'Contract'; bytecode: string } | null;
-};
 
-export type GQLContractBalanceNodeFragment = {
-  __typename: 'ContractBalance';
-  amount: string;
-  assetId: string;
-};
+export type GQLContractQuery = { __typename: 'Query', contract?: { __typename: 'Contract', bytecode: string } | null };
 
-export type GQLContractBalanceConnectionNodeFragment = {
-  __typename: 'ContractBalanceConnection';
-  edges: Array<{
-    __typename: 'ContractBalanceEdge';
-    cursor: string;
-    node: { __typename: 'ContractBalance'; amount: string; assetId: string };
-  }>;
-  pageInfo: {
-    __typename: 'PageInfo';
-    hasNextPage: boolean;
-    hasPreviousPage: boolean;
-    endCursor?: string | null;
-    startCursor?: string | null;
-  };
-};
+export type GQLContractBalanceNodeFragment = { __typename: 'ContractBalance', amount: string, assetId: string };
+
+export type GQLContractBalanceConnectionNodeFragment = { __typename: 'ContractBalanceConnection', edges: Array<{ __typename: 'ContractBalanceEdge', cursor: string, node: { __typename: 'ContractBalance', amount: string, assetId: string } }>, pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null, startCursor?: string | null } };
 
 export type GQLContractBalancesQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -2668,51 +1509,17 @@ export type GQLContractBalancesQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLContractBalancesQuery = {
-  __typename: 'Query';
-  contractBalances: {
-    __typename: 'ContractBalanceConnection';
-    edges: Array<{
-      __typename: 'ContractBalanceEdge';
-      cursor: string;
-      node: { __typename: 'ContractBalance'; amount: string; assetId: string };
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      endCursor?: string | null;
-      startCursor?: string | null;
-    };
-  };
-};
+
+export type GQLContractBalancesQuery = { __typename: 'Query', contractBalances: { __typename: 'ContractBalanceConnection', edges: Array<{ __typename: 'ContractBalanceEdge', cursor: string, node: { __typename: 'ContractBalance', amount: string, assetId: string } }>, pageInfo: { __typename: 'PageInfo', hasNextPage: boolean, hasPreviousPage: boolean, endCursor?: string | null, startCursor?: string | null } } };
 
 export type GQLPredicateQueryVariables = Exact<{
   address: Scalars['String']['input'];
 }>;
 
-export type GQLPredicateQuery = {
-  __typename: 'Query';
-  predicate?: {
-    __typename: 'PredicateItem';
-    address?: string | null;
-    bytecode?: string | null;
-  } | null;
-};
 
-export type GQLRecentTransactionFragment = {
-  __typename: 'Transaction';
-  _id?: string | null;
-  id: string;
-  title: string;
-  statusType?: string | null;
-  time: {
-    __typename: 'ParsedTime';
-    fromNow?: string | null;
-    rawUnix?: string | null;
-  };
-  gasCosts?: { __typename: 'TransactionGasCosts'; fee?: string | null } | null;
-};
+export type GQLPredicateQuery = { __typename: 'Query', predicate?: { __typename: 'PredicateItem', address?: string | null, bytecode?: string | null } | null };
+
+export type GQLRecentTransactionFragment = { __typename: 'Transaction', _id?: string | null, id: string, title: string, statusType?: string | null, time: { __typename: 'ParsedTime', fromNow?: string | null, rawUnix?: string | null }, gasCosts?: { __typename: 'TransactionGasCosts', fee?: string | null } | null };
 
 export type GQLRecentTransactionsQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -2721,566 +1528,22 @@ export type GQLRecentTransactionsQueryVariables = Exact<{
   last?: InputMaybe<Scalars['Int']['input']>;
 }>;
 
-export type GQLRecentTransactionsQuery = {
-  __typename: 'Query';
-  transactions: {
-    __typename: 'TransactionConnection';
-    nodes: Array<{
-      __typename: 'Transaction';
-      _id?: string | null;
-      id: string;
-      title: string;
-      statusType?: string | null;
-      time: {
-        __typename: 'ParsedTime';
-        fromNow?: string | null;
-        rawUnix?: string | null;
-      };
-      gasCosts?: {
-        __typename: 'TransactionGasCosts';
-        fee?: string | null;
-      } | null;
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      endCursor?: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-    };
-  };
-};
+
+export type GQLRecentTransactionsQuery = { __typename: 'Query', transactions: { __typename: 'TransactionConnection', nodes: Array<{ __typename: 'Transaction', _id?: string | null, id: string, title: string, statusType?: string | null, time: { __typename: 'ParsedTime', fromNow?: string | null, rawUnix?: string | null }, gasCosts?: { __typename: 'TransactionGasCosts', fee?: string | null } | null }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type GQLSearchQueryVariables = Exact<{
   query: Scalars['String']['input'];
 }>;
 
-export type GQLSearchQuery = {
-  __typename: 'Query';
-  search?: {
-    __typename: 'SearchResult';
-    account?: {
-      __typename: 'SearchAccount';
-      address?: string | null;
-      transactions?: Array<{
-        __typename: 'SearchTransaction';
-        id?: string | null;
-      } | null> | null;
-    } | null;
-    block?: {
-      __typename: 'SearchBlock';
-      height?: string | null;
-      id?: string | null;
-    } | null;
-    contract?: { __typename: 'SearchContract'; id?: string | null } | null;
-    transaction?: {
-      __typename: 'SearchTransaction';
-      id?: string | null;
-    } | null;
-  } | null;
-};
+
+export type GQLSearchQuery = { __typename: 'Query', search?: { __typename: 'SearchResult', account?: { __typename: 'SearchAccount', address?: string | null, transactions?: Array<{ __typename: 'SearchTransaction', id?: string | null } | null> | null } | null, block?: { __typename: 'SearchBlock', height?: string | null, id?: string | null } | null, contract?: { __typename: 'SearchContract', id?: string | null } | null, transaction?: { __typename: 'SearchTransaction', id?: string | null } | null } | null };
 
 export type GQLTransactionDetailsQueryVariables = Exact<{
   id: Scalars['TransactionId']['input'];
 }>;
 
-export type GQLTransactionDetailsQuery = {
-  __typename: 'Query';
-  transaction?: {
-    __typename: 'Transaction';
-    id: string;
-    blockHeight?: string | null;
-    hasPredicate?: boolean | null;
-    statusType?: string | null;
-    title: string;
-    maturity?: string | null;
-    txPointer?: string | null;
-    isScript: boolean;
-    isCreate: boolean;
-    isMint: boolean;
-    witnesses?: Array<string> | null;
-    receiptsRoot?: string | null;
-    script?: string | null;
-    scriptData?: string | null;
-    bytecodeWitnessIndex?: string | null;
-    salt?: string | null;
-    storageSlots?: Array<string> | null;
-    rawPayload: string;
-    mintAmount?: string | null;
-    mintAssetId?: string | null;
-    inputAssetIds?: Array<string> | null;
-    inputContracts?: Array<string> | null;
-    gasCosts?: {
-      __typename: 'TransactionGasCosts';
-      fee?: string | null;
-      gasUsed?: string | null;
-    } | null;
-    groupedInputs: Array<
-      | {
-          __typename: 'GroupedInputCoin';
-          type?: GQLGroupedInputType | null;
-          totalAmount?: string | null;
-          owner?: string | null;
-          assetId?: string | null;
-          inputs?: Array<
-            | { __typename: 'InputCoin'; amount: string; utxoId: string }
-            | { __typename: 'InputContract' }
-            | { __typename: 'InputMessage' }
-          > | null;
-        }
-      | {
-          __typename: 'GroupedInputContract';
-          type?: GQLGroupedInputType | null;
-          contractId?: string | null;
-        }
-      | {
-          __typename: 'GroupedInputMessage';
-          type?: GQLGroupedInputType | null;
-          sender?: string | null;
-          data?: string | null;
-          recipient?: string | null;
-        }
-    >;
-    groupedOutputs: Array<
-      | {
-          __typename: 'GroupedOutputChanged';
-          type?: GQLGroupedOutputType | null;
-          assetId?: string | null;
-          totalAmount?: string | null;
-          to?: string | null;
-          outputs?: Array<
-            | { __typename: 'ChangeOutput' }
-            | { __typename: 'CoinOutput' }
-            | { __typename: 'ContractCreated' }
-            | { __typename: 'ContractOutput' }
-            | { __typename: 'VariableOutput' }
-            | null
-          > | null;
-        }
-      | {
-          __typename: 'GroupedOutputCoin';
-          type?: GQLGroupedOutputType | null;
-          assetId?: string | null;
-          totalAmount?: string | null;
-          to?: string | null;
-          outputs?: Array<
-            | { __typename: 'ChangeOutput' }
-            | { __typename: 'CoinOutput' }
-            | { __typename: 'ContractCreated' }
-            | { __typename: 'ContractOutput' }
-            | { __typename: 'VariableOutput' }
-            | null
-          > | null;
-        }
-      | {
-          __typename: 'GroupedOutputContractCreated';
-          type?: GQLGroupedOutputType | null;
-          contractId?: string | null;
-        }
-    >;
-    operations?: Array<{
-      __typename: 'Operation';
-      type?: GQLOperationType | null;
-      receipts?: Array<{
-        __typename: 'OperationReceipt';
-        receipts?: Array<{
-          __typename: 'OperationReceipt';
-          receipts?: Array<{
-            __typename: 'OperationReceipt';
-            receipts?: Array<{
-              __typename: 'OperationReceipt';
-              receipts?: Array<{
-                __typename: 'OperationReceipt';
-                receipts?: Array<{
-                  __typename: 'OperationReceipt';
-                  receipts?: Array<{
-                    __typename: 'OperationReceipt';
-                    receipts?: Array<{
-                      __typename: 'OperationReceipt';
-                      item?: {
-                        __typename: 'Receipt';
-                        id?: string | null;
-                        to?: string | null;
-                        pc?: string | null;
-                        is?: string | null;
-                        toAddress?: string | null;
-                        amount?: string | null;
-                        assetId?: string | null;
-                        gas?: string | null;
-                        param1?: string | null;
-                        param2?: string | null;
-                        val?: string | null;
-                        ptr?: string | null;
-                        digest?: string | null;
-                        reason?: string | null;
-                        ra?: string | null;
-                        rb?: string | null;
-                        rc?: string | null;
-                        rd?: string | null;
-                        len?: string | null;
-                        receiptType: GQLReceiptType;
-                        result?: string | null;
-                        gasUsed?: string | null;
-                        data?: string | null;
-                        sender?: string | null;
-                        recipient?: string | null;
-                        nonce?: string | null;
-                        contractId?: string | null;
-                        subId?: string | null;
-                      } | null;
-                    }> | null;
-                    item?: {
-                      __typename: 'Receipt';
-                      id?: string | null;
-                      to?: string | null;
-                      pc?: string | null;
-                      is?: string | null;
-                      toAddress?: string | null;
-                      amount?: string | null;
-                      assetId?: string | null;
-                      gas?: string | null;
-                      param1?: string | null;
-                      param2?: string | null;
-                      val?: string | null;
-                      ptr?: string | null;
-                      digest?: string | null;
-                      reason?: string | null;
-                      ra?: string | null;
-                      rb?: string | null;
-                      rc?: string | null;
-                      rd?: string | null;
-                      len?: string | null;
-                      receiptType: GQLReceiptType;
-                      result?: string | null;
-                      gasUsed?: string | null;
-                      data?: string | null;
-                      sender?: string | null;
-                      recipient?: string | null;
-                      nonce?: string | null;
-                      contractId?: string | null;
-                      subId?: string | null;
-                    } | null;
-                  }> | null;
-                  item?: {
-                    __typename: 'Receipt';
-                    id?: string | null;
-                    to?: string | null;
-                    pc?: string | null;
-                    is?: string | null;
-                    toAddress?: string | null;
-                    amount?: string | null;
-                    assetId?: string | null;
-                    gas?: string | null;
-                    param1?: string | null;
-                    param2?: string | null;
-                    val?: string | null;
-                    ptr?: string | null;
-                    digest?: string | null;
-                    reason?: string | null;
-                    ra?: string | null;
-                    rb?: string | null;
-                    rc?: string | null;
-                    rd?: string | null;
-                    len?: string | null;
-                    receiptType: GQLReceiptType;
-                    result?: string | null;
-                    gasUsed?: string | null;
-                    data?: string | null;
-                    sender?: string | null;
-                    recipient?: string | null;
-                    nonce?: string | null;
-                    contractId?: string | null;
-                    subId?: string | null;
-                  } | null;
-                }> | null;
-                item?: {
-                  __typename: 'Receipt';
-                  id?: string | null;
-                  to?: string | null;
-                  pc?: string | null;
-                  is?: string | null;
-                  toAddress?: string | null;
-                  amount?: string | null;
-                  assetId?: string | null;
-                  gas?: string | null;
-                  param1?: string | null;
-                  param2?: string | null;
-                  val?: string | null;
-                  ptr?: string | null;
-                  digest?: string | null;
-                  reason?: string | null;
-                  ra?: string | null;
-                  rb?: string | null;
-                  rc?: string | null;
-                  rd?: string | null;
-                  len?: string | null;
-                  receiptType: GQLReceiptType;
-                  result?: string | null;
-                  gasUsed?: string | null;
-                  data?: string | null;
-                  sender?: string | null;
-                  recipient?: string | null;
-                  nonce?: string | null;
-                  contractId?: string | null;
-                  subId?: string | null;
-                } | null;
-              }> | null;
-              item?: {
-                __typename: 'Receipt';
-                id?: string | null;
-                to?: string | null;
-                pc?: string | null;
-                is?: string | null;
-                toAddress?: string | null;
-                amount?: string | null;
-                assetId?: string | null;
-                gas?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                val?: string | null;
-                ptr?: string | null;
-                digest?: string | null;
-                reason?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                len?: string | null;
-                receiptType: GQLReceiptType;
-                result?: string | null;
-                gasUsed?: string | null;
-                data?: string | null;
-                sender?: string | null;
-                recipient?: string | null;
-                nonce?: string | null;
-                contractId?: string | null;
-                subId?: string | null;
-              } | null;
-            }> | null;
-            item?: {
-              __typename: 'Receipt';
-              id?: string | null;
-              to?: string | null;
-              pc?: string | null;
-              is?: string | null;
-              toAddress?: string | null;
-              amount?: string | null;
-              assetId?: string | null;
-              gas?: string | null;
-              param1?: string | null;
-              param2?: string | null;
-              val?: string | null;
-              ptr?: string | null;
-              digest?: string | null;
-              reason?: string | null;
-              ra?: string | null;
-              rb?: string | null;
-              rc?: string | null;
-              rd?: string | null;
-              len?: string | null;
-              receiptType: GQLReceiptType;
-              result?: string | null;
-              gasUsed?: string | null;
-              data?: string | null;
-              sender?: string | null;
-              recipient?: string | null;
-              nonce?: string | null;
-              contractId?: string | null;
-              subId?: string | null;
-            } | null;
-          }> | null;
-          item?: {
-            __typename: 'Receipt';
-            id?: string | null;
-            to?: string | null;
-            pc?: string | null;
-            is?: string | null;
-            toAddress?: string | null;
-            amount?: string | null;
-            assetId?: string | null;
-            gas?: string | null;
-            param1?: string | null;
-            param2?: string | null;
-            val?: string | null;
-            ptr?: string | null;
-            digest?: string | null;
-            reason?: string | null;
-            ra?: string | null;
-            rb?: string | null;
-            rc?: string | null;
-            rd?: string | null;
-            len?: string | null;
-            receiptType: GQLReceiptType;
-            result?: string | null;
-            gasUsed?: string | null;
-            data?: string | null;
-            sender?: string | null;
-            recipient?: string | null;
-            nonce?: string | null;
-            contractId?: string | null;
-            subId?: string | null;
-          } | null;
-        }> | null;
-        item?: {
-          __typename: 'Receipt';
-          id?: string | null;
-          to?: string | null;
-          pc?: string | null;
-          is?: string | null;
-          toAddress?: string | null;
-          amount?: string | null;
-          assetId?: string | null;
-          gas?: string | null;
-          param1?: string | null;
-          param2?: string | null;
-          val?: string | null;
-          ptr?: string | null;
-          digest?: string | null;
-          reason?: string | null;
-          ra?: string | null;
-          rb?: string | null;
-          rc?: string | null;
-          rd?: string | null;
-          len?: string | null;
-          receiptType: GQLReceiptType;
-          result?: string | null;
-          gasUsed?: string | null;
-          data?: string | null;
-          sender?: string | null;
-          recipient?: string | null;
-          nonce?: string | null;
-          contractId?: string | null;
-          subId?: string | null;
-        } | null;
-      }> | null;
-    }> | null;
-    receipts?: Array<{
-      __typename: 'Receipt';
-      id?: string | null;
-      to?: string | null;
-      pc?: string | null;
-      is?: string | null;
-      toAddress?: string | null;
-      amount?: string | null;
-      assetId?: string | null;
-      gas?: string | null;
-      param1?: string | null;
-      param2?: string | null;
-      val?: string | null;
-      ptr?: string | null;
-      digest?: string | null;
-      reason?: string | null;
-      ra?: string | null;
-      rb?: string | null;
-      rc?: string | null;
-      rd?: string | null;
-      len?: string | null;
-      receiptType: GQLReceiptType;
-      result?: string | null;
-      gasUsed?: string | null;
-      data?: string | null;
-      sender?: string | null;
-      recipient?: string | null;
-      nonce?: string | null;
-      contractId?: string | null;
-      subId?: string | null;
-    }> | null;
-    time: {
-      __typename: 'ParsedTime';
-      fromNow?: string | null;
-      full?: string | null;
-      rawUnix?: string | null;
-    };
-    inputContract?: { __typename: 'InputContract'; contractId: string } | null;
-    outputContract?: {
-      __typename: 'ContractOutput';
-      inputIndex: string;
-    } | null;
-    status?:
-      | {
-          __typename: 'FailureStatus';
-          time: string;
-          programState?: { __typename: 'ProgramState'; data: string } | null;
-        }
-      | { __typename: 'SqueezedOutStatus'; reason: string }
-      | { __typename: 'SubmittedStatus'; time: string }
-      | {
-          __typename: 'SuccessStatus';
-          time: string;
-          block: {
-            __typename: 'Block';
-            id: string;
-            header: {
-              __typename: 'Header';
-              id: string;
-              height: string;
-              daHeight: string;
-              applicationHash: string;
-              messageReceiptCount: string;
-              time: string;
-            };
-          };
-          programState?: { __typename: 'ProgramState'; data: string } | null;
-        }
-      | null;
-    inputs?: Array<
-      | {
-          __typename: 'InputCoin';
-          amount: string;
-          assetId: string;
-          owner: string;
-          predicate: string;
-          predicateData: string;
-          txPointer: string;
-          utxoId: string;
-          witnessIndex: string;
-        }
-      | {
-          __typename: 'InputContract';
-          utxoId: string;
-          balanceRoot: string;
-          txPointer: string;
-          contractId: string;
-        }
-      | {
-          __typename: 'InputMessage';
-          sender: string;
-          recipient: string;
-          amount: string;
-          nonce: string;
-          data: string;
-          predicate: string;
-          predicateData: string;
-        }
-    > | null;
-    outputs: Array<
-      | {
-          __typename: 'ChangeOutput';
-          to: string;
-          amount: string;
-          assetId: string;
-        }
-      | {
-          __typename: 'CoinOutput';
-          to: string;
-          amount: string;
-          assetId: string;
-        }
-      | { __typename: 'ContractCreated'; contract: string }
-      | {
-          __typename: 'ContractOutput';
-          inputIndex: string;
-          balanceRoot: string;
-        }
-      | {
-          __typename: 'VariableOutput';
-          to: string;
-          amount: string;
-          assetId: string;
-        }
-    >;
-  } | null;
-};
+
+export type GQLTransactionDetailsQuery = { __typename: 'Query', transaction?: { __typename: 'Transaction', id: string, blockHeight?: string | null, hasPredicate?: boolean | null, statusType?: string | null, title: string, maturity?: string | null, txPointer?: string | null, isScript: boolean, isCreate: boolean, isMint: boolean, witnesses?: Array<string> | null, receiptsRoot?: string | null, script?: string | null, scriptData?: string | null, bytecodeWitnessIndex?: string | null, salt?: string | null, storageSlots?: Array<string> | null, rawPayload: string, mintAmount?: string | null, mintAssetId?: string | null, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, gasCosts?: { __typename: 'TransactionGasCosts', fee?: string | null, gasUsed?: string | null } | null, groupedInputs: Array<{ __typename: 'GroupedInputCoin', type?: GQLGroupedInputType | null, totalAmount?: string | null, owner?: string | null, assetId?: string | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, utxoId: string } | { __typename: 'InputContract' } | { __typename: 'InputMessage' }> | null } | { __typename: 'GroupedInputContract', type?: GQLGroupedInputType | null, contractId?: string | null } | { __typename: 'GroupedInputMessage', type?: GQLGroupedInputType | null, sender?: string | null, data?: string | null, recipient?: string | null }>, groupedOutputs: Array<{ __typename: 'GroupedOutputChanged', type?: GQLGroupedOutputType | null, assetId?: string | null, totalAmount?: string | null, to?: string | null, outputs?: Array<{ __typename: 'ChangeOutput' } | { __typename: 'CoinOutput' } | { __typename: 'ContractCreated' } | { __typename: 'ContractOutput' } | { __typename: 'VariableOutput' } | null> | null } | { __typename: 'GroupedOutputCoin', type?: GQLGroupedOutputType | null, assetId?: string | null, totalAmount?: string | null, to?: string | null, outputs?: Array<{ __typename: 'ChangeOutput' } | { __typename: 'CoinOutput' } | { __typename: 'ContractCreated' } | { __typename: 'ContractOutput' } | { __typename: 'VariableOutput' } | null> | null } | { __typename: 'GroupedOutputContractCreated', type?: GQLGroupedOutputType | null, contractId?: string | null }>, operations?: Array<{ __typename: 'Operation', type?: GQLOperationType | null, receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null }> | null, receipts?: Array<{ __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null }> | null, time: { __typename: 'ParsedTime', fromNow?: string | null, full?: string | null, rawUnix?: string | null }, inputContract?: { __typename: 'InputContract', contractId: string } | null, outputContract?: { __typename: 'ContractOutput', inputIndex: string } | null, status?: { __typename: 'FailureStatus', time: string, programState?: { __typename: 'ProgramState', data: string } | null } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, block: { __typename: 'Block', id: string, header: { __typename: 'Header', id: string, height: string, daHeight: string, applicationHash: string, messageReceiptCount: string, time: string } }, programState?: { __typename: 'ProgramState', data: string } | null } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', utxoId: string, balanceRoot: string, txPointer: string, contractId: string } | { __typename: 'InputMessage', sender: string, recipient: string, amount: string, nonce: string, data: string, predicate: string, predicateData: string }> | null, outputs: Array<{ __typename: 'ChangeOutput', to: string, amount: string, assetId: string } | { __typename: 'CoinOutput', to: string, amount: string, assetId: string } | { __typename: 'ContractCreated', contract: string } | { __typename: 'ContractOutput', inputIndex: string, balanceRoot: string } | { __typename: 'VariableOutput', to: string, amount: string, assetId: string }> } | null };
 
 export type GQLTransactionsByBlockIdQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -3290,35 +1553,8 @@ export type GQLTransactionsByBlockIdQueryVariables = Exact<{
   blockId: Scalars['String']['input'];
 }>;
 
-export type GQLTransactionsByBlockIdQuery = {
-  __typename: 'Query';
-  transactionsByBlockId: {
-    __typename: 'TransactionConnection';
-    nodes: Array<{
-      __typename: 'Transaction';
-      _id?: string | null;
-      id: string;
-      title: string;
-      statusType?: string | null;
-      time: {
-        __typename: 'ParsedTime';
-        fromNow?: string | null;
-        rawUnix?: string | null;
-      };
-      gasCosts?: {
-        __typename: 'TransactionGasCosts';
-        fee?: string | null;
-      } | null;
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      endCursor?: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-    };
-  };
-};
+
+export type GQLTransactionsByBlockIdQuery = { __typename: 'Query', transactionsByBlockId: { __typename: 'TransactionConnection', nodes: Array<{ __typename: 'Transaction', _id?: string | null, id: string, title: string, statusType?: string | null, time: { __typename: 'ParsedTime', fromNow?: string | null, rawUnix?: string | null }, gasCosts?: { __typename: 'TransactionGasCosts', fee?: string | null } | null }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
 export type GQLTransactionsByOwnerQueryVariables = Exact<{
   after?: InputMaybe<Scalars['String']['input']>;
@@ -3328,1180 +1564,60 @@ export type GQLTransactionsByOwnerQueryVariables = Exact<{
   owner: Scalars['Address']['input'];
 }>;
 
-export type GQLTransactionsByOwnerQuery = {
-  __typename: 'Query';
-  transactionsByOwner: {
-    __typename: 'TransactionConnection';
-    nodes: Array<{
-      __typename: 'Transaction';
-      _id?: string | null;
-      id: string;
-      title: string;
-      statusType?: string | null;
-      time: {
-        __typename: 'ParsedTime';
-        fromNow?: string | null;
-        rawUnix?: string | null;
-      };
-      gasCosts?: {
-        __typename: 'TransactionGasCosts';
-        fee?: string | null;
-      } | null;
-    }>;
-    pageInfo: {
-      __typename: 'PageInfo';
-      endCursor?: string | null;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-      startCursor?: string | null;
-    };
-  };
-};
 
-type GQLTransactionStatus_FailureStatus_Fragment = {
-  __typename: 'FailureStatus';
-  time: string;
-  programState?: { __typename: 'ProgramState'; data: string } | null;
-};
+export type GQLTransactionsByOwnerQuery = { __typename: 'Query', transactionsByOwner: { __typename: 'TransactionConnection', nodes: Array<{ __typename: 'Transaction', _id?: string | null, id: string, title: string, statusType?: string | null, time: { __typename: 'ParsedTime', fromNow?: string | null, rawUnix?: string | null }, gasCosts?: { __typename: 'TransactionGasCosts', fee?: string | null } | null }>, pageInfo: { __typename: 'PageInfo', endCursor?: string | null, hasNextPage: boolean, hasPreviousPage: boolean, startCursor?: string | null } } };
 
-type GQLTransactionStatus_SqueezedOutStatus_Fragment = {
-  __typename: 'SqueezedOutStatus';
-  reason: string;
-};
+type GQLTransactionStatus_FailureStatus_Fragment = { __typename: 'FailureStatus', time: string, programState?: { __typename: 'ProgramState', data: string } | null };
 
-type GQLTransactionStatus_SubmittedStatus_Fragment = {
-  __typename: 'SubmittedStatus';
-  time: string;
-};
+type GQLTransactionStatus_SqueezedOutStatus_Fragment = { __typename: 'SqueezedOutStatus', reason: string };
 
-type GQLTransactionStatus_SuccessStatus_Fragment = {
-  __typename: 'SuccessStatus';
-  time: string;
-  block: {
-    __typename: 'Block';
-    id: string;
-    header: {
-      __typename: 'Header';
-      id: string;
-      height: string;
-      daHeight: string;
-      applicationHash: string;
-      messageReceiptCount: string;
-      time: string;
-    };
-  };
-  programState?: { __typename: 'ProgramState'; data: string } | null;
-};
+type GQLTransactionStatus_SubmittedStatus_Fragment = { __typename: 'SubmittedStatus', time: string };
 
-export type GQLTransactionStatusFragment =
-  | GQLTransactionStatus_FailureStatus_Fragment
-  | GQLTransactionStatus_SqueezedOutStatus_Fragment
-  | GQLTransactionStatus_SubmittedStatus_Fragment
-  | GQLTransactionStatus_SuccessStatus_Fragment;
+type GQLTransactionStatus_SuccessStatus_Fragment = { __typename: 'SuccessStatus', time: string, block: { __typename: 'Block', id: string, header: { __typename: 'Header', id: string, height: string, daHeight: string, applicationHash: string, messageReceiptCount: string, time: string } }, programState?: { __typename: 'ProgramState', data: string } | null };
 
-type GQLTransactionInput_InputCoin_Fragment = {
-  __typename: 'InputCoin';
-  amount: string;
-  assetId: string;
-  owner: string;
-  predicate: string;
-  predicateData: string;
-  txPointer: string;
-  utxoId: string;
-  witnessIndex: string;
-};
+export type GQLTransactionStatusFragment = GQLTransactionStatus_FailureStatus_Fragment | GQLTransactionStatus_SqueezedOutStatus_Fragment | GQLTransactionStatus_SubmittedStatus_Fragment | GQLTransactionStatus_SuccessStatus_Fragment;
 
-type GQLTransactionInput_InputContract_Fragment = {
-  __typename: 'InputContract';
-  utxoId: string;
-  balanceRoot: string;
-  txPointer: string;
-  contractId: string;
-};
+type GQLTransactionInput_InputCoin_Fragment = { __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, txPointer: string, utxoId: string, witnessIndex: string };
 
-type GQLTransactionInput_InputMessage_Fragment = {
-  __typename: 'InputMessage';
-  sender: string;
-  recipient: string;
-  amount: string;
-  nonce: string;
-  data: string;
-  predicate: string;
-  predicateData: string;
-};
+type GQLTransactionInput_InputContract_Fragment = { __typename: 'InputContract', utxoId: string, balanceRoot: string, txPointer: string, contractId: string };
 
-export type GQLTransactionInputFragment =
-  | GQLTransactionInput_InputCoin_Fragment
-  | GQLTransactionInput_InputContract_Fragment
-  | GQLTransactionInput_InputMessage_Fragment;
+type GQLTransactionInput_InputMessage_Fragment = { __typename: 'InputMessage', sender: string, recipient: string, amount: string, nonce: string, data: string, predicate: string, predicateData: string };
 
-type GQLTransactionOutput_ChangeOutput_Fragment = {
-  __typename: 'ChangeOutput';
-  to: string;
-  amount: string;
-  assetId: string;
-};
+export type GQLTransactionInputFragment = GQLTransactionInput_InputCoin_Fragment | GQLTransactionInput_InputContract_Fragment | GQLTransactionInput_InputMessage_Fragment;
 
-type GQLTransactionOutput_CoinOutput_Fragment = {
-  __typename: 'CoinOutput';
-  to: string;
-  amount: string;
-  assetId: string;
-};
+type GQLTransactionOutput_ChangeOutput_Fragment = { __typename: 'ChangeOutput', to: string, amount: string, assetId: string };
 
-type GQLTransactionOutput_ContractCreated_Fragment = {
-  __typename: 'ContractCreated';
-  contract: string;
-};
+type GQLTransactionOutput_CoinOutput_Fragment = { __typename: 'CoinOutput', to: string, amount: string, assetId: string };
 
-type GQLTransactionOutput_ContractOutput_Fragment = {
-  __typename: 'ContractOutput';
-  inputIndex: string;
-  balanceRoot: string;
-};
+type GQLTransactionOutput_ContractCreated_Fragment = { __typename: 'ContractCreated', contract: string };
 
-type GQLTransactionOutput_VariableOutput_Fragment = {
-  __typename: 'VariableOutput';
-  to: string;
-  amount: string;
-  assetId: string;
-};
+type GQLTransactionOutput_ContractOutput_Fragment = { __typename: 'ContractOutput', inputIndex: string, balanceRoot: string };
 
-export type GQLTransactionOutputFragment =
-  | GQLTransactionOutput_ChangeOutput_Fragment
-  | GQLTransactionOutput_CoinOutput_Fragment
-  | GQLTransactionOutput_ContractCreated_Fragment
-  | GQLTransactionOutput_ContractOutput_Fragment
-  | GQLTransactionOutput_VariableOutput_Fragment;
+type GQLTransactionOutput_VariableOutput_Fragment = { __typename: 'VariableOutput', to: string, amount: string, assetId: string };
 
-export type GQLTransactionReceiptFragment = {
-  __typename: 'Receipt';
-  id?: string | null;
-  to?: string | null;
-  pc?: string | null;
-  is?: string | null;
-  toAddress?: string | null;
-  amount?: string | null;
-  assetId?: string | null;
-  gas?: string | null;
-  param1?: string | null;
-  param2?: string | null;
-  val?: string | null;
-  ptr?: string | null;
-  digest?: string | null;
-  reason?: string | null;
-  ra?: string | null;
-  rb?: string | null;
-  rc?: string | null;
-  rd?: string | null;
-  len?: string | null;
-  receiptType: GQLReceiptType;
-  result?: string | null;
-  gasUsed?: string | null;
-  data?: string | null;
-  sender?: string | null;
-  recipient?: string | null;
-  nonce?: string | null;
-  contractId?: string | null;
-  subId?: string | null;
-};
+export type GQLTransactionOutputFragment = GQLTransactionOutput_ChangeOutput_Fragment | GQLTransactionOutput_CoinOutput_Fragment | GQLTransactionOutput_ContractCreated_Fragment | GQLTransactionOutput_ContractOutput_Fragment | GQLTransactionOutput_VariableOutput_Fragment;
 
-export type GQLInnerReceiptItemFragment = {
-  __typename: 'OperationReceipt';
-  item?: {
-    __typename: 'Receipt';
-    id?: string | null;
-    to?: string | null;
-    pc?: string | null;
-    is?: string | null;
-    toAddress?: string | null;
-    amount?: string | null;
-    assetId?: string | null;
-    gas?: string | null;
-    param1?: string | null;
-    param2?: string | null;
-    val?: string | null;
-    ptr?: string | null;
-    digest?: string | null;
-    reason?: string | null;
-    ra?: string | null;
-    rb?: string | null;
-    rc?: string | null;
-    rd?: string | null;
-    len?: string | null;
-    receiptType: GQLReceiptType;
-    result?: string | null;
-    gasUsed?: string | null;
-    data?: string | null;
-    sender?: string | null;
-    recipient?: string | null;
-    nonce?: string | null;
-    contractId?: string | null;
-    subId?: string | null;
-  } | null;
-};
+export type GQLTransactionReceiptFragment = { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null };
 
-export type GQLOperationReceiptItemFragment = {
-  __typename: 'OperationReceipt';
-  receipts?: Array<{
-    __typename: 'OperationReceipt';
-    receipts?: Array<{
-      __typename: 'OperationReceipt';
-      receipts?: Array<{
-        __typename: 'OperationReceipt';
-        item?: {
-          __typename: 'Receipt';
-          id?: string | null;
-          to?: string | null;
-          pc?: string | null;
-          is?: string | null;
-          toAddress?: string | null;
-          amount?: string | null;
-          assetId?: string | null;
-          gas?: string | null;
-          param1?: string | null;
-          param2?: string | null;
-          val?: string | null;
-          ptr?: string | null;
-          digest?: string | null;
-          reason?: string | null;
-          ra?: string | null;
-          rb?: string | null;
-          rc?: string | null;
-          rd?: string | null;
-          len?: string | null;
-          receiptType: GQLReceiptType;
-          result?: string | null;
-          gasUsed?: string | null;
-          data?: string | null;
-          sender?: string | null;
-          recipient?: string | null;
-          nonce?: string | null;
-          contractId?: string | null;
-          subId?: string | null;
-        } | null;
-      }> | null;
-      item?: {
-        __typename: 'Receipt';
-        id?: string | null;
-        to?: string | null;
-        pc?: string | null;
-        is?: string | null;
-        toAddress?: string | null;
-        amount?: string | null;
-        assetId?: string | null;
-        gas?: string | null;
-        param1?: string | null;
-        param2?: string | null;
-        val?: string | null;
-        ptr?: string | null;
-        digest?: string | null;
-        reason?: string | null;
-        ra?: string | null;
-        rb?: string | null;
-        rc?: string | null;
-        rd?: string | null;
-        len?: string | null;
-        receiptType: GQLReceiptType;
-        result?: string | null;
-        gasUsed?: string | null;
-        data?: string | null;
-        sender?: string | null;
-        recipient?: string | null;
-        nonce?: string | null;
-        contractId?: string | null;
-        subId?: string | null;
-      } | null;
-    }> | null;
-    item?: {
-      __typename: 'Receipt';
-      id?: string | null;
-      to?: string | null;
-      pc?: string | null;
-      is?: string | null;
-      toAddress?: string | null;
-      amount?: string | null;
-      assetId?: string | null;
-      gas?: string | null;
-      param1?: string | null;
-      param2?: string | null;
-      val?: string | null;
-      ptr?: string | null;
-      digest?: string | null;
-      reason?: string | null;
-      ra?: string | null;
-      rb?: string | null;
-      rc?: string | null;
-      rd?: string | null;
-      len?: string | null;
-      receiptType: GQLReceiptType;
-      result?: string | null;
-      gasUsed?: string | null;
-      data?: string | null;
-      sender?: string | null;
-      recipient?: string | null;
-      nonce?: string | null;
-      contractId?: string | null;
-      subId?: string | null;
-    } | null;
-  }> | null;
-  item?: {
-    __typename: 'Receipt';
-    id?: string | null;
-    to?: string | null;
-    pc?: string | null;
-    is?: string | null;
-    toAddress?: string | null;
-    amount?: string | null;
-    assetId?: string | null;
-    gas?: string | null;
-    param1?: string | null;
-    param2?: string | null;
-    val?: string | null;
-    ptr?: string | null;
-    digest?: string | null;
-    reason?: string | null;
-    ra?: string | null;
-    rb?: string | null;
-    rc?: string | null;
-    rd?: string | null;
-    len?: string | null;
-    receiptType: GQLReceiptType;
-    result?: string | null;
-    gasUsed?: string | null;
-    data?: string | null;
-    sender?: string | null;
-    recipient?: string | null;
-    nonce?: string | null;
-    contractId?: string | null;
-    subId?: string | null;
-  } | null;
-};
+export type GQLInnerReceiptItemFragment = { __typename: 'OperationReceipt', item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null };
 
-export type GQLOperationItemFragment = {
-  __typename: 'Operation';
-  type?: GQLOperationType | null;
-  receipts?: Array<{
-    __typename: 'OperationReceipt';
-    receipts?: Array<{
-      __typename: 'OperationReceipt';
-      receipts?: Array<{
-        __typename: 'OperationReceipt';
-        receipts?: Array<{
-          __typename: 'OperationReceipt';
-          receipts?: Array<{
-            __typename: 'OperationReceipt';
-            receipts?: Array<{
-              __typename: 'OperationReceipt';
-              receipts?: Array<{
-                __typename: 'OperationReceipt';
-                receipts?: Array<{
-                  __typename: 'OperationReceipt';
-                  item?: {
-                    __typename: 'Receipt';
-                    id?: string | null;
-                    to?: string | null;
-                    pc?: string | null;
-                    is?: string | null;
-                    toAddress?: string | null;
-                    amount?: string | null;
-                    assetId?: string | null;
-                    gas?: string | null;
-                    param1?: string | null;
-                    param2?: string | null;
-                    val?: string | null;
-                    ptr?: string | null;
-                    digest?: string | null;
-                    reason?: string | null;
-                    ra?: string | null;
-                    rb?: string | null;
-                    rc?: string | null;
-                    rd?: string | null;
-                    len?: string | null;
-                    receiptType: GQLReceiptType;
-                    result?: string | null;
-                    gasUsed?: string | null;
-                    data?: string | null;
-                    sender?: string | null;
-                    recipient?: string | null;
-                    nonce?: string | null;
-                    contractId?: string | null;
-                    subId?: string | null;
-                  } | null;
-                }> | null;
-                item?: {
-                  __typename: 'Receipt';
-                  id?: string | null;
-                  to?: string | null;
-                  pc?: string | null;
-                  is?: string | null;
-                  toAddress?: string | null;
-                  amount?: string | null;
-                  assetId?: string | null;
-                  gas?: string | null;
-                  param1?: string | null;
-                  param2?: string | null;
-                  val?: string | null;
-                  ptr?: string | null;
-                  digest?: string | null;
-                  reason?: string | null;
-                  ra?: string | null;
-                  rb?: string | null;
-                  rc?: string | null;
-                  rd?: string | null;
-                  len?: string | null;
-                  receiptType: GQLReceiptType;
-                  result?: string | null;
-                  gasUsed?: string | null;
-                  data?: string | null;
-                  sender?: string | null;
-                  recipient?: string | null;
-                  nonce?: string | null;
-                  contractId?: string | null;
-                  subId?: string | null;
-                } | null;
-              }> | null;
-              item?: {
-                __typename: 'Receipt';
-                id?: string | null;
-                to?: string | null;
-                pc?: string | null;
-                is?: string | null;
-                toAddress?: string | null;
-                amount?: string | null;
-                assetId?: string | null;
-                gas?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                val?: string | null;
-                ptr?: string | null;
-                digest?: string | null;
-                reason?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                len?: string | null;
-                receiptType: GQLReceiptType;
-                result?: string | null;
-                gasUsed?: string | null;
-                data?: string | null;
-                sender?: string | null;
-                recipient?: string | null;
-                nonce?: string | null;
-                contractId?: string | null;
-                subId?: string | null;
-              } | null;
-            }> | null;
-            item?: {
-              __typename: 'Receipt';
-              id?: string | null;
-              to?: string | null;
-              pc?: string | null;
-              is?: string | null;
-              toAddress?: string | null;
-              amount?: string | null;
-              assetId?: string | null;
-              gas?: string | null;
-              param1?: string | null;
-              param2?: string | null;
-              val?: string | null;
-              ptr?: string | null;
-              digest?: string | null;
-              reason?: string | null;
-              ra?: string | null;
-              rb?: string | null;
-              rc?: string | null;
-              rd?: string | null;
-              len?: string | null;
-              receiptType: GQLReceiptType;
-              result?: string | null;
-              gasUsed?: string | null;
-              data?: string | null;
-              sender?: string | null;
-              recipient?: string | null;
-              nonce?: string | null;
-              contractId?: string | null;
-              subId?: string | null;
-            } | null;
-          }> | null;
-          item?: {
-            __typename: 'Receipt';
-            id?: string | null;
-            to?: string | null;
-            pc?: string | null;
-            is?: string | null;
-            toAddress?: string | null;
-            amount?: string | null;
-            assetId?: string | null;
-            gas?: string | null;
-            param1?: string | null;
-            param2?: string | null;
-            val?: string | null;
-            ptr?: string | null;
-            digest?: string | null;
-            reason?: string | null;
-            ra?: string | null;
-            rb?: string | null;
-            rc?: string | null;
-            rd?: string | null;
-            len?: string | null;
-            receiptType: GQLReceiptType;
-            result?: string | null;
-            gasUsed?: string | null;
-            data?: string | null;
-            sender?: string | null;
-            recipient?: string | null;
-            nonce?: string | null;
-            contractId?: string | null;
-            subId?: string | null;
-          } | null;
-        }> | null;
-        item?: {
-          __typename: 'Receipt';
-          id?: string | null;
-          to?: string | null;
-          pc?: string | null;
-          is?: string | null;
-          toAddress?: string | null;
-          amount?: string | null;
-          assetId?: string | null;
-          gas?: string | null;
-          param1?: string | null;
-          param2?: string | null;
-          val?: string | null;
-          ptr?: string | null;
-          digest?: string | null;
-          reason?: string | null;
-          ra?: string | null;
-          rb?: string | null;
-          rc?: string | null;
-          rd?: string | null;
-          len?: string | null;
-          receiptType: GQLReceiptType;
-          result?: string | null;
-          gasUsed?: string | null;
-          data?: string | null;
-          sender?: string | null;
-          recipient?: string | null;
-          nonce?: string | null;
-          contractId?: string | null;
-          subId?: string | null;
-        } | null;
-      }> | null;
-      item?: {
-        __typename: 'Receipt';
-        id?: string | null;
-        to?: string | null;
-        pc?: string | null;
-        is?: string | null;
-        toAddress?: string | null;
-        amount?: string | null;
-        assetId?: string | null;
-        gas?: string | null;
-        param1?: string | null;
-        param2?: string | null;
-        val?: string | null;
-        ptr?: string | null;
-        digest?: string | null;
-        reason?: string | null;
-        ra?: string | null;
-        rb?: string | null;
-        rc?: string | null;
-        rd?: string | null;
-        len?: string | null;
-        receiptType: GQLReceiptType;
-        result?: string | null;
-        gasUsed?: string | null;
-        data?: string | null;
-        sender?: string | null;
-        recipient?: string | null;
-        nonce?: string | null;
-        contractId?: string | null;
-        subId?: string | null;
-      } | null;
-    }> | null;
-    item?: {
-      __typename: 'Receipt';
-      id?: string | null;
-      to?: string | null;
-      pc?: string | null;
-      is?: string | null;
-      toAddress?: string | null;
-      amount?: string | null;
-      assetId?: string | null;
-      gas?: string | null;
-      param1?: string | null;
-      param2?: string | null;
-      val?: string | null;
-      ptr?: string | null;
-      digest?: string | null;
-      reason?: string | null;
-      ra?: string | null;
-      rb?: string | null;
-      rc?: string | null;
-      rd?: string | null;
-      len?: string | null;
-      receiptType: GQLReceiptType;
-      result?: string | null;
-      gasUsed?: string | null;
-      data?: string | null;
-      sender?: string | null;
-      recipient?: string | null;
-      nonce?: string | null;
-      contractId?: string | null;
-      subId?: string | null;
-    } | null;
-  }> | null;
-};
+export type GQLOperationReceiptItemFragment = { __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null };
 
-export type GQLTxDetailsGroupedInputCoinFragment = {
-  __typename: 'GroupedInputCoin';
-  type?: GQLGroupedInputType | null;
-  totalAmount?: string | null;
-  owner?: string | null;
-  assetId?: string | null;
-  inputs?: Array<
-    | { __typename: 'InputCoin'; amount: string; utxoId: string }
-    | { __typename: 'InputContract' }
-    | { __typename: 'InputMessage' }
-  > | null;
-};
+export type GQLOperationItemFragment = { __typename: 'Operation', type?: GQLOperationType | null, receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null };
 
-export type GQLTxDetailsGroupedInputMessageFragment = {
-  __typename: 'GroupedInputMessage';
-  type?: GQLGroupedInputType | null;
-  sender?: string | null;
-  data?: string | null;
-  recipient?: string | null;
-};
+export type GQLTxDetailsGroupedInputCoinFragment = { __typename: 'GroupedInputCoin', type?: GQLGroupedInputType | null, totalAmount?: string | null, owner?: string | null, assetId?: string | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, utxoId: string } | { __typename: 'InputContract' } | { __typename: 'InputMessage' }> | null };
 
-export type GQLTxDetailsGroupedInputContractFragment = {
-  __typename: 'GroupedInputContract';
-  type?: GQLGroupedInputType | null;
-  contractId?: string | null;
-};
+export type GQLTxDetailsGroupedInputMessageFragment = { __typename: 'GroupedInputMessage', type?: GQLGroupedInputType | null, sender?: string | null, data?: string | null, recipient?: string | null };
 
-export type GQLTxDetailsGroupedOutputCoinFragment = {
-  __typename: 'GroupedOutputCoin';
-  type?: GQLGroupedOutputType | null;
-  assetId?: string | null;
-  totalAmount?: string | null;
-  to?: string | null;
-  outputs?: Array<
-    | { __typename: 'ChangeOutput' }
-    | { __typename: 'CoinOutput' }
-    | { __typename: 'ContractCreated' }
-    | { __typename: 'ContractOutput' }
-    | { __typename: 'VariableOutput' }
-    | null
-  > | null;
-};
+export type GQLTxDetailsGroupedInputContractFragment = { __typename: 'GroupedInputContract', type?: GQLGroupedInputType | null, contractId?: string | null };
 
-export type GQLTxDetailsGroupedOutputChangedFragment = {
-  __typename: 'GroupedOutputChanged';
-  type?: GQLGroupedOutputType | null;
-  assetId?: string | null;
-  totalAmount?: string | null;
-  to?: string | null;
-  outputs?: Array<
-    | { __typename: 'ChangeOutput' }
-    | { __typename: 'CoinOutput' }
-    | { __typename: 'ContractCreated' }
-    | { __typename: 'ContractOutput' }
-    | { __typename: 'VariableOutput' }
-    | null
-  > | null;
-};
+export type GQLTxDetailsGroupedOutputCoinFragment = { __typename: 'GroupedOutputCoin', type?: GQLGroupedOutputType | null, assetId?: string | null, totalAmount?: string | null, to?: string | null, outputs?: Array<{ __typename: 'ChangeOutput' } | { __typename: 'CoinOutput' } | { __typename: 'ContractCreated' } | { __typename: 'ContractOutput' } | { __typename: 'VariableOutput' } | null> | null };
 
-export type GQLTxDetailsGroupedOutputContractCreatedFragment = {
-  __typename: 'GroupedOutputContractCreated';
-  type?: GQLGroupedOutputType | null;
-  contractId?: string | null;
-};
+export type GQLTxDetailsGroupedOutputChangedFragment = { __typename: 'GroupedOutputChanged', type?: GQLGroupedOutputType | null, assetId?: string | null, totalAmount?: string | null, to?: string | null, outputs?: Array<{ __typename: 'ChangeOutput' } | { __typename: 'CoinOutput' } | { __typename: 'ContractCreated' } | { __typename: 'ContractOutput' } | { __typename: 'VariableOutput' } | null> | null };
 
-export type GQLTransactionItemFragment = {
-  __typename: 'Transaction';
-  id: string;
-  blockHeight?: string | null;
-  hasPredicate?: boolean | null;
-  statusType?: string | null;
-  title: string;
-  maturity?: string | null;
-  txPointer?: string | null;
-  isScript: boolean;
-  isCreate: boolean;
-  isMint: boolean;
-  witnesses?: Array<string> | null;
-  receiptsRoot?: string | null;
-  script?: string | null;
-  scriptData?: string | null;
-  bytecodeWitnessIndex?: string | null;
-  salt?: string | null;
-  storageSlots?: Array<string> | null;
-  rawPayload: string;
-  mintAmount?: string | null;
-  mintAssetId?: string | null;
-  inputAssetIds?: Array<string> | null;
-  inputContracts?: Array<string> | null;
-  gasCosts?: {
-    __typename: 'TransactionGasCosts';
-    fee?: string | null;
-    gasUsed?: string | null;
-  } | null;
-  groupedInputs: Array<
-    | {
-        __typename: 'GroupedInputCoin';
-        type?: GQLGroupedInputType | null;
-        totalAmount?: string | null;
-        owner?: string | null;
-        assetId?: string | null;
-        inputs?: Array<
-          | { __typename: 'InputCoin'; amount: string; utxoId: string }
-          | { __typename: 'InputContract' }
-          | { __typename: 'InputMessage' }
-        > | null;
-      }
-    | {
-        __typename: 'GroupedInputContract';
-        type?: GQLGroupedInputType | null;
-        contractId?: string | null;
-      }
-    | {
-        __typename: 'GroupedInputMessage';
-        type?: GQLGroupedInputType | null;
-        sender?: string | null;
-        data?: string | null;
-        recipient?: string | null;
-      }
-  >;
-  groupedOutputs: Array<
-    | {
-        __typename: 'GroupedOutputChanged';
-        type?: GQLGroupedOutputType | null;
-        assetId?: string | null;
-        totalAmount?: string | null;
-        to?: string | null;
-        outputs?: Array<
-          | { __typename: 'ChangeOutput' }
-          | { __typename: 'CoinOutput' }
-          | { __typename: 'ContractCreated' }
-          | { __typename: 'ContractOutput' }
-          | { __typename: 'VariableOutput' }
-          | null
-        > | null;
-      }
-    | {
-        __typename: 'GroupedOutputCoin';
-        type?: GQLGroupedOutputType | null;
-        assetId?: string | null;
-        totalAmount?: string | null;
-        to?: string | null;
-        outputs?: Array<
-          | { __typename: 'ChangeOutput' }
-          | { __typename: 'CoinOutput' }
-          | { __typename: 'ContractCreated' }
-          | { __typename: 'ContractOutput' }
-          | { __typename: 'VariableOutput' }
-          | null
-        > | null;
-      }
-    | {
-        __typename: 'GroupedOutputContractCreated';
-        type?: GQLGroupedOutputType | null;
-        contractId?: string | null;
-      }
-  >;
-  operations?: Array<{
-    __typename: 'Operation';
-    type?: GQLOperationType | null;
-    receipts?: Array<{
-      __typename: 'OperationReceipt';
-      receipts?: Array<{
-        __typename: 'OperationReceipt';
-        receipts?: Array<{
-          __typename: 'OperationReceipt';
-          receipts?: Array<{
-            __typename: 'OperationReceipt';
-            receipts?: Array<{
-              __typename: 'OperationReceipt';
-              receipts?: Array<{
-                __typename: 'OperationReceipt';
-                receipts?: Array<{
-                  __typename: 'OperationReceipt';
-                  receipts?: Array<{
-                    __typename: 'OperationReceipt';
-                    item?: {
-                      __typename: 'Receipt';
-                      id?: string | null;
-                      to?: string | null;
-                      pc?: string | null;
-                      is?: string | null;
-                      toAddress?: string | null;
-                      amount?: string | null;
-                      assetId?: string | null;
-                      gas?: string | null;
-                      param1?: string | null;
-                      param2?: string | null;
-                      val?: string | null;
-                      ptr?: string | null;
-                      digest?: string | null;
-                      reason?: string | null;
-                      ra?: string | null;
-                      rb?: string | null;
-                      rc?: string | null;
-                      rd?: string | null;
-                      len?: string | null;
-                      receiptType: GQLReceiptType;
-                      result?: string | null;
-                      gasUsed?: string | null;
-                      data?: string | null;
-                      sender?: string | null;
-                      recipient?: string | null;
-                      nonce?: string | null;
-                      contractId?: string | null;
-                      subId?: string | null;
-                    } | null;
-                  }> | null;
-                  item?: {
-                    __typename: 'Receipt';
-                    id?: string | null;
-                    to?: string | null;
-                    pc?: string | null;
-                    is?: string | null;
-                    toAddress?: string | null;
-                    amount?: string | null;
-                    assetId?: string | null;
-                    gas?: string | null;
-                    param1?: string | null;
-                    param2?: string | null;
-                    val?: string | null;
-                    ptr?: string | null;
-                    digest?: string | null;
-                    reason?: string | null;
-                    ra?: string | null;
-                    rb?: string | null;
-                    rc?: string | null;
-                    rd?: string | null;
-                    len?: string | null;
-                    receiptType: GQLReceiptType;
-                    result?: string | null;
-                    gasUsed?: string | null;
-                    data?: string | null;
-                    sender?: string | null;
-                    recipient?: string | null;
-                    nonce?: string | null;
-                    contractId?: string | null;
-                    subId?: string | null;
-                  } | null;
-                }> | null;
-                item?: {
-                  __typename: 'Receipt';
-                  id?: string | null;
-                  to?: string | null;
-                  pc?: string | null;
-                  is?: string | null;
-                  toAddress?: string | null;
-                  amount?: string | null;
-                  assetId?: string | null;
-                  gas?: string | null;
-                  param1?: string | null;
-                  param2?: string | null;
-                  val?: string | null;
-                  ptr?: string | null;
-                  digest?: string | null;
-                  reason?: string | null;
-                  ra?: string | null;
-                  rb?: string | null;
-                  rc?: string | null;
-                  rd?: string | null;
-                  len?: string | null;
-                  receiptType: GQLReceiptType;
-                  result?: string | null;
-                  gasUsed?: string | null;
-                  data?: string | null;
-                  sender?: string | null;
-                  recipient?: string | null;
-                  nonce?: string | null;
-                  contractId?: string | null;
-                  subId?: string | null;
-                } | null;
-              }> | null;
-              item?: {
-                __typename: 'Receipt';
-                id?: string | null;
-                to?: string | null;
-                pc?: string | null;
-                is?: string | null;
-                toAddress?: string | null;
-                amount?: string | null;
-                assetId?: string | null;
-                gas?: string | null;
-                param1?: string | null;
-                param2?: string | null;
-                val?: string | null;
-                ptr?: string | null;
-                digest?: string | null;
-                reason?: string | null;
-                ra?: string | null;
-                rb?: string | null;
-                rc?: string | null;
-                rd?: string | null;
-                len?: string | null;
-                receiptType: GQLReceiptType;
-                result?: string | null;
-                gasUsed?: string | null;
-                data?: string | null;
-                sender?: string | null;
-                recipient?: string | null;
-                nonce?: string | null;
-                contractId?: string | null;
-                subId?: string | null;
-              } | null;
-            }> | null;
-            item?: {
-              __typename: 'Receipt';
-              id?: string | null;
-              to?: string | null;
-              pc?: string | null;
-              is?: string | null;
-              toAddress?: string | null;
-              amount?: string | null;
-              assetId?: string | null;
-              gas?: string | null;
-              param1?: string | null;
-              param2?: string | null;
-              val?: string | null;
-              ptr?: string | null;
-              digest?: string | null;
-              reason?: string | null;
-              ra?: string | null;
-              rb?: string | null;
-              rc?: string | null;
-              rd?: string | null;
-              len?: string | null;
-              receiptType: GQLReceiptType;
-              result?: string | null;
-              gasUsed?: string | null;
-              data?: string | null;
-              sender?: string | null;
-              recipient?: string | null;
-              nonce?: string | null;
-              contractId?: string | null;
-              subId?: string | null;
-            } | null;
-          }> | null;
-          item?: {
-            __typename: 'Receipt';
-            id?: string | null;
-            to?: string | null;
-            pc?: string | null;
-            is?: string | null;
-            toAddress?: string | null;
-            amount?: string | null;
-            assetId?: string | null;
-            gas?: string | null;
-            param1?: string | null;
-            param2?: string | null;
-            val?: string | null;
-            ptr?: string | null;
-            digest?: string | null;
-            reason?: string | null;
-            ra?: string | null;
-            rb?: string | null;
-            rc?: string | null;
-            rd?: string | null;
-            len?: string | null;
-            receiptType: GQLReceiptType;
-            result?: string | null;
-            gasUsed?: string | null;
-            data?: string | null;
-            sender?: string | null;
-            recipient?: string | null;
-            nonce?: string | null;
-            contractId?: string | null;
-            subId?: string | null;
-          } | null;
-        }> | null;
-        item?: {
-          __typename: 'Receipt';
-          id?: string | null;
-          to?: string | null;
-          pc?: string | null;
-          is?: string | null;
-          toAddress?: string | null;
-          amount?: string | null;
-          assetId?: string | null;
-          gas?: string | null;
-          param1?: string | null;
-          param2?: string | null;
-          val?: string | null;
-          ptr?: string | null;
-          digest?: string | null;
-          reason?: string | null;
-          ra?: string | null;
-          rb?: string | null;
-          rc?: string | null;
-          rd?: string | null;
-          len?: string | null;
-          receiptType: GQLReceiptType;
-          result?: string | null;
-          gasUsed?: string | null;
-          data?: string | null;
-          sender?: string | null;
-          recipient?: string | null;
-          nonce?: string | null;
-          contractId?: string | null;
-          subId?: string | null;
-        } | null;
-      }> | null;
-      item?: {
-        __typename: 'Receipt';
-        id?: string | null;
-        to?: string | null;
-        pc?: string | null;
-        is?: string | null;
-        toAddress?: string | null;
-        amount?: string | null;
-        assetId?: string | null;
-        gas?: string | null;
-        param1?: string | null;
-        param2?: string | null;
-        val?: string | null;
-        ptr?: string | null;
-        digest?: string | null;
-        reason?: string | null;
-        ra?: string | null;
-        rb?: string | null;
-        rc?: string | null;
-        rd?: string | null;
-        len?: string | null;
-        receiptType: GQLReceiptType;
-        result?: string | null;
-        gasUsed?: string | null;
-        data?: string | null;
-        sender?: string | null;
-        recipient?: string | null;
-        nonce?: string | null;
-        contractId?: string | null;
-        subId?: string | null;
-      } | null;
-    }> | null;
-  }> | null;
-  receipts?: Array<{
-    __typename: 'Receipt';
-    id?: string | null;
-    to?: string | null;
-    pc?: string | null;
-    is?: string | null;
-    toAddress?: string | null;
-    amount?: string | null;
-    assetId?: string | null;
-    gas?: string | null;
-    param1?: string | null;
-    param2?: string | null;
-    val?: string | null;
-    ptr?: string | null;
-    digest?: string | null;
-    reason?: string | null;
-    ra?: string | null;
-    rb?: string | null;
-    rc?: string | null;
-    rd?: string | null;
-    len?: string | null;
-    receiptType: GQLReceiptType;
-    result?: string | null;
-    gasUsed?: string | null;
-    data?: string | null;
-    sender?: string | null;
-    recipient?: string | null;
-    nonce?: string | null;
-    contractId?: string | null;
-    subId?: string | null;
-  }> | null;
-  time: {
-    __typename: 'ParsedTime';
-    fromNow?: string | null;
-    full?: string | null;
-    rawUnix?: string | null;
-  };
-  inputContract?: { __typename: 'InputContract'; contractId: string } | null;
-  outputContract?: { __typename: 'ContractOutput'; inputIndex: string } | null;
-  status?:
-    | {
-        __typename: 'FailureStatus';
-        time: string;
-        programState?: { __typename: 'ProgramState'; data: string } | null;
-      }
-    | { __typename: 'SqueezedOutStatus'; reason: string }
-    | { __typename: 'SubmittedStatus'; time: string }
-    | {
-        __typename: 'SuccessStatus';
-        time: string;
-        block: {
-          __typename: 'Block';
-          id: string;
-          header: {
-            __typename: 'Header';
-            id: string;
-            height: string;
-            daHeight: string;
-            applicationHash: string;
-            messageReceiptCount: string;
-            time: string;
-          };
-        };
-        programState?: { __typename: 'ProgramState'; data: string } | null;
-      }
-    | null;
-  inputs?: Array<
-    | {
-        __typename: 'InputCoin';
-        amount: string;
-        assetId: string;
-        owner: string;
-        predicate: string;
-        predicateData: string;
-        txPointer: string;
-        utxoId: string;
-        witnessIndex: string;
-      }
-    | {
-        __typename: 'InputContract';
-        utxoId: string;
-        balanceRoot: string;
-        txPointer: string;
-        contractId: string;
-      }
-    | {
-        __typename: 'InputMessage';
-        sender: string;
-        recipient: string;
-        amount: string;
-        nonce: string;
-        data: string;
-        predicate: string;
-        predicateData: string;
-      }
-  > | null;
-  outputs: Array<
-    | {
-        __typename: 'ChangeOutput';
-        to: string;
-        amount: string;
-        assetId: string;
-      }
-    | { __typename: 'CoinOutput'; to: string; amount: string; assetId: string }
-    | { __typename: 'ContractCreated'; contract: string }
-    | { __typename: 'ContractOutput'; inputIndex: string; balanceRoot: string }
-    | {
-        __typename: 'VariableOutput';
-        to: string;
-        amount: string;
-        assetId: string;
-      }
-  >;
-};
+export type GQLTxDetailsGroupedOutputContractCreatedFragment = { __typename: 'GroupedOutputContractCreated', type?: GQLGroupedOutputType | null, contractId?: string | null };
+
+export type GQLTransactionItemFragment = { __typename: 'Transaction', id: string, blockHeight?: string | null, hasPredicate?: boolean | null, statusType?: string | null, title: string, maturity?: string | null, txPointer?: string | null, isScript: boolean, isCreate: boolean, isMint: boolean, witnesses?: Array<string> | null, receiptsRoot?: string | null, script?: string | null, scriptData?: string | null, bytecodeWitnessIndex?: string | null, salt?: string | null, storageSlots?: Array<string> | null, rawPayload: string, mintAmount?: string | null, mintAssetId?: string | null, inputAssetIds?: Array<string> | null, inputContracts?: Array<string> | null, gasCosts?: { __typename: 'TransactionGasCosts', fee?: string | null, gasUsed?: string | null } | null, groupedInputs: Array<{ __typename: 'GroupedInputCoin', type?: GQLGroupedInputType | null, totalAmount?: string | null, owner?: string | null, assetId?: string | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, utxoId: string } | { __typename: 'InputContract' } | { __typename: 'InputMessage' }> | null } | { __typename: 'GroupedInputContract', type?: GQLGroupedInputType | null, contractId?: string | null } | { __typename: 'GroupedInputMessage', type?: GQLGroupedInputType | null, sender?: string | null, data?: string | null, recipient?: string | null }>, groupedOutputs: Array<{ __typename: 'GroupedOutputChanged', type?: GQLGroupedOutputType | null, assetId?: string | null, totalAmount?: string | null, to?: string | null, outputs?: Array<{ __typename: 'ChangeOutput' } | { __typename: 'CoinOutput' } | { __typename: 'ContractCreated' } | { __typename: 'ContractOutput' } | { __typename: 'VariableOutput' } | null> | null } | { __typename: 'GroupedOutputCoin', type?: GQLGroupedOutputType | null, assetId?: string | null, totalAmount?: string | null, to?: string | null, outputs?: Array<{ __typename: 'ChangeOutput' } | { __typename: 'CoinOutput' } | { __typename: 'ContractCreated' } | { __typename: 'ContractOutput' } | { __typename: 'VariableOutput' } | null> | null } | { __typename: 'GroupedOutputContractCreated', type?: GQLGroupedOutputType | null, contractId?: string | null }>, operations?: Array<{ __typename: 'Operation', type?: GQLOperationType | null, receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', receipts?: Array<{ __typename: 'OperationReceipt', item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null, item?: { __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null } | null }> | null }> | null, receipts?: Array<{ __typename: 'Receipt', id?: string | null, to?: string | null, pc?: string | null, is?: string | null, toAddress?: string | null, amount?: string | null, assetId?: string | null, gas?: string | null, param1?: string | null, param2?: string | null, val?: string | null, ptr?: string | null, digest?: string | null, reason?: string | null, ra?: string | null, rb?: string | null, rc?: string | null, rd?: string | null, len?: string | null, receiptType: GQLReceiptType, result?: string | null, gasUsed?: string | null, data?: string | null, sender?: string | null, recipient?: string | null, nonce?: string | null, contractId?: string | null, subId?: string | null }> | null, time: { __typename: 'ParsedTime', fromNow?: string | null, full?: string | null, rawUnix?: string | null }, inputContract?: { __typename: 'InputContract', contractId: string } | null, outputContract?: { __typename: 'ContractOutput', inputIndex: string } | null, status?: { __typename: 'FailureStatus', time: string, programState?: { __typename: 'ProgramState', data: string } | null } | { __typename: 'SqueezedOutStatus', reason: string } | { __typename: 'SubmittedStatus', time: string } | { __typename: 'SuccessStatus', time: string, block: { __typename: 'Block', id: string, header: { __typename: 'Header', id: string, height: string, daHeight: string, applicationHash: string, messageReceiptCount: string, time: string } }, programState?: { __typename: 'ProgramState', data: string } | null } | null, inputs?: Array<{ __typename: 'InputCoin', amount: string, assetId: string, owner: string, predicate: string, predicateData: string, txPointer: string, utxoId: string, witnessIndex: string } | { __typename: 'InputContract', utxoId: string, balanceRoot: string, txPointer: string, contractId: string } | { __typename: 'InputMessage', sender: string, recipient: string, amount: string, nonce: string, data: string, predicate: string, predicateData: string }> | null, outputs: Array<{ __typename: 'ChangeOutput', to: string, amount: string, assetId: string } | { __typename: 'CoinOutput', to: string, amount: string, assetId: string } | { __typename: 'ContractCreated', contract: string } | { __typename: 'ContractOutput', inputIndex: string, balanceRoot: string } | { __typename: 'VariableOutput', to: string, amount: string, assetId: string }> };
 
 export const BalanceItemFragmentDoc = gql`
     fragment BalanceItem on Balance {
@@ -6362,19 +3478,10 @@ export const TransactionsByOwnerDocument = gql`
 }
     ${RecentTransactionFragmentDoc}`;
 
-export type SdkFunctionWrapper = <T>(
-  action: (requestHeaders?: Record<string, string>) => Promise<T>,
-  operationName: string,
-  operationType?: string,
-  variables?: any,
-) => Promise<T>;
+export type SdkFunctionWrapper = <T>(action: (requestHeaders?:Record<string, string>) => Promise<T>, operationName: string, operationType?: string, variables?: any) => Promise<T>;
 
-const defaultWrapper: SdkFunctionWrapper = (
-  action,
-  _operationName,
-  _operationType,
-  _variables,
-) => action();
+
+const defaultWrapper: SdkFunctionWrapper = (action, _operationName, _operationType, _variables) => action();
 const BalancesDocumentString = print(BalancesDocument);
 const BlockDocumentString = print(BlockDocument);
 const BlocksDocumentString = print(BlocksDocument);
@@ -6386,296 +3493,49 @@ const PredicateDocumentString = print(PredicateDocument);
 const RecentTransactionsDocumentString = print(RecentTransactionsDocument);
 const SearchDocumentString = print(SearchDocument);
 const TransactionDetailsDocumentString = print(TransactionDetailsDocument);
-const TransactionsByBlockIdDocumentString = print(
-  TransactionsByBlockIdDocument,
-);
+const TransactionsByBlockIdDocumentString = print(TransactionsByBlockIdDocument);
 const TransactionsByOwnerDocumentString = print(TransactionsByOwnerDocument);
-export function getSdk(
-  client: GraphQLClient,
-  withWrapper: SdkFunctionWrapper = defaultWrapper,
-) {
+export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   return {
-    balances(
-      variables: GQLBalancesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLBalancesQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLBalancesQuery>(
-            BalancesDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'balances',
-        'query',
-        variables,
-      );
+    balances(variables: GQLBalancesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBalancesQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBalancesQuery>(BalancesDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'balances', 'query', variables);
     },
-    block(
-      variables?: GQLBlockQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLBlockQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLBlockQuery>(BlockDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'block',
-        'query',
-        variables,
-      );
+    block(variables?: GQLBlockQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBlockQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBlockQuery>(BlockDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'block', 'query', variables);
     },
-    blocks(
-      variables?: GQLBlocksQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLBlocksQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLBlocksQuery>(BlocksDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'blocks',
-        'query',
-        variables,
-      );
+    blocks(variables?: GQLBlocksQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLBlocksQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLBlocksQuery>(BlocksDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'blocks', 'query', variables);
     },
-    chain(
-      variables?: GQLChainQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLChainQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLChainQuery>(ChainDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'chain',
-        'query',
-        variables,
-      );
+    chain(variables?: GQLChainQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLChainQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLChainQuery>(ChainDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'chain', 'query', variables);
     },
-    coins(
-      variables: GQLCoinsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLCoinsQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLCoinsQuery>(CoinsDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'coins',
-        'query',
-        variables,
-      );
+    coins(variables: GQLCoinsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLCoinsQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLCoinsQuery>(CoinsDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'coins', 'query', variables);
     },
-    contract(
-      variables: GQLContractQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLContractQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLContractQuery>(
-            ContractDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'contract',
-        'query',
-        variables,
-      );
+    contract(variables: GQLContractQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLContractQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLContractQuery>(ContractDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'contract', 'query', variables);
     },
-    contractBalances(
-      variables: GQLContractBalancesQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLContractBalancesQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLContractBalancesQuery>(
-            ContractBalancesDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'contractBalances',
-        'query',
-        variables,
-      );
+    contractBalances(variables: GQLContractBalancesQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLContractBalancesQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLContractBalancesQuery>(ContractBalancesDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'contractBalances', 'query', variables);
     },
-    predicate(
-      variables: GQLPredicateQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLPredicateQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLPredicateQuery>(
-            PredicateDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'predicate',
-        'query',
-        variables,
-      );
+    predicate(variables: GQLPredicateQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLPredicateQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLPredicateQuery>(PredicateDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'predicate', 'query', variables);
     },
-    recentTransactions(
-      variables?: GQLRecentTransactionsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLRecentTransactionsQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLRecentTransactionsQuery>(
-            RecentTransactionsDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'recentTransactions',
-        'query',
-        variables,
-      );
+    recentTransactions(variables?: GQLRecentTransactionsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLRecentTransactionsQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLRecentTransactionsQuery>(RecentTransactionsDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'recentTransactions', 'query', variables);
     },
-    search(
-      variables: GQLSearchQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLSearchQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLSearchQuery>(SearchDocumentString, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        'search',
-        'query',
-        variables,
-      );
+    search(variables: GQLSearchQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLSearchQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLSearchQuery>(SearchDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'search', 'query', variables);
     },
-    transactionDetails(
-      variables: GQLTransactionDetailsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLTransactionDetailsQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLTransactionDetailsQuery>(
-            TransactionDetailsDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'transactionDetails',
-        'query',
-        variables,
-      );
+    transactionDetails(variables: GQLTransactionDetailsQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLTransactionDetailsQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLTransactionDetailsQuery>(TransactionDetailsDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'transactionDetails', 'query', variables);
     },
-    transactionsByBlockId(
-      variables: GQLTransactionsByBlockIdQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLTransactionsByBlockIdQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLTransactionsByBlockIdQuery>(
-            TransactionsByBlockIdDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'transactionsByBlockId',
-        'query',
-        variables,
-      );
+    transactionsByBlockId(variables: GQLTransactionsByBlockIdQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLTransactionsByBlockIdQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLTransactionsByBlockIdQuery>(TransactionsByBlockIdDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'transactionsByBlockId', 'query', variables);
     },
-    transactionsByOwner(
-      variables: GQLTransactionsByOwnerQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<{
-      data: GQLTransactionsByOwnerQuery;
-      errors?: GraphQLError[];
-      extensions?: any;
-      headers: Headers;
-      status: number;
-    }> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.rawRequest<GQLTransactionsByOwnerQuery>(
-            TransactionsByOwnerDocumentString,
-            variables,
-            { ...requestHeaders, ...wrappedRequestHeaders },
-          ),
-        'transactionsByOwner',
-        'query',
-        variables,
-      );
-    },
+    transactionsByOwner(variables: GQLTransactionsByOwnerQueryVariables, requestHeaders?: GraphQLClientRequestHeaders): Promise<{ data: GQLTransactionsByOwnerQuery; errors?: GraphQLError[]; extensions?: any; headers: Headers; status: number; }> {
+        return withWrapper((wrappedRequestHeaders) => client.rawRequest<GQLTransactionsByOwnerQuery>(TransactionsByOwnerDocumentString, variables, {...requestHeaders, ...wrappedRequestHeaders}), 'transactionsByOwner', 'query', variables);
+    }
   };
 }
 export type Sdk = ReturnType<typeof getSdk>;

--- a/packages/graphql/src/graphql/generated/sdk.ts
+++ b/packages/graphql/src/graphql/generated/sdk.ts
@@ -837,6 +837,7 @@ export enum GQLOperationType {
   FinalResult = 'FINAL_RESULT',
   FromAccount = 'FROM_ACCOUNT',
   FromContract = 'FROM_CONTRACT',
+  Rootless = 'ROOTLESS',
 }
 
 export type GQLOperationsFilterInput = {

--- a/packages/graphql/src/graphql/schemas/explorer.graphql
+++ b/packages/graphql/src/graphql/schemas/explorer.graphql
@@ -114,6 +114,7 @@ enum OperationType {
   FROM_CONTRACT
   FROM_ACCOUNT
   FINAL_RESULT
+  ROOTLESS
 }
 
 type OperationReceipt {

--- a/packages/ui/src/components/Address/Address.tsx
+++ b/packages/ui/src/components/Address/Address.tsx
@@ -39,7 +39,7 @@ const AddressSpan = ({
   short: string;
   className?: string;
 }) => {
-  const baseClass = cx(['text-[1em]', className]);
+  const baseClass = cx(['text-sm', className]);
   return (
     <>
       {full && (
@@ -96,7 +96,7 @@ export const Address = createComponent<AddressProps, 'div'>({
                 {linkProps ? (
                   <Link
                     {...linkProps}
-                    className={cx('text-xs text-[1em]')}
+                    className={cx('text-xs text-sm')}
                     onClick={(e) => {
                       e.stopPropagation();
                     }}
@@ -128,7 +128,7 @@ export const Address = createComponent<AddressProps, 'div'>({
 const styles = tv({
   slots: {
     root: 'flex gap-1 text-sm font-mono',
-    prefix: 'mr-px text-[1em] text-secondary',
-    address: 'text-[1em] text-muted mt-px gap-3',
+    prefix: 'mr-px text-sm text-secondary',
+    address: 'text-sm text-muted mt-px gap-3',
   },
 });


### PR DESCRIPTION
Closes #533 

# Changes 
## Txs GQL
- Receipts without a root operation are now included in the `operations` array with a new type `Rootless`

## Transaction Page
- [Fix] Not displaying `MESSAGE_OUT` receipts from operations, now all receipts present are rendered in operations;
- [Fix] Not displaying `ContractOutput` and `VariableOutput`
- [Refactor] All Inputs, Operations and Outputs now display information in the same pattern (e.g. Text & Icon badges, amounts, information positioning, etc)

# Evidence

## Desktop
![localhost_3001_tx_0x3ca5f1eaf7aa400c32f2a699bee35f6e7f6289fa77756e5889b3cc2d7270ee98_simple](https://github.com/user-attachments/assets/146e9be0-e9a6-4722-a10c-bb47fd76f6f1)


## Mobile
![localhost_3001_tx_0x3ca5f1eaf7aa400c32f2a699bee35f6e7f6289fa77756e5889b3cc2d7270ee98_simple(iPhone 14 Pro Max)](https://github.com/user-attachments/assets/3ab9ba5e-5260-4cb5-9709-9d0898d71d91)


