### PR TITLE
fix: fuel core chain config

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Test Node
-        timeout-minutes: 3
+        timeout-minutes: 7
         run: pnpm node:start
 
       # E2E tests running with Playwright
@@ -62,7 +62,7 @@ jobs:
   tests-e2e-soft:
     name: E2E Tests Soft
     runs-on: buildjet-4vcpu-ubuntu-2204
-    timeout-minutes: 7
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Start Test Node
-        timeout-minutes: 3
+        timeout-minutes: 7
         run: pnpm node:start
 
       # E2E tests running with Playwright

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       # expose the service to the host for integration testing
       - 8545:9545
       - ${DEPLOYMENTS_PORT:-8080}:8081
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-H", "Content-Type: application/json", "-d", "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"net_version\",\"params\":[]}", "http://localhost:9545"]
+      interval: 5s
+      timeout: 5s
+      retries: 10000
     networks:
       - app-network
 
@@ -24,7 +29,7 @@ services:
     platform: linux/amd64
     depends_on:
       l1_chain:
-        condition: service_started
+        condition: service_healthy
     build:
       context: ./fuel-core/
     environment:
@@ -34,7 +39,7 @@ services:
       # expose the service to the host for integration testing
       - ${FUEL_CORE_HTTP_PORT:-4000}:4001
     healthcheck:
-      test: curl --fail http://localhost:4001/v1/health || exit 1
+      test: ["CMD", "curl", "-f", "http://localhost:4001/v1/health || exit 1"]
       interval: 10s
       timeout: 10s
       retries: 100

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       - 8545:9545
       - ${DEPLOYMENTS_PORT:-8080}:8081
     healthcheck:
-      test: ["CMD", "curl", "-f", "-H", "Content-Type: application/json", "-d", "{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"net_version\",\"params\":[]}", "http://localhost:9545"]
+      test: "curl -f -H \"Content-Type: application/json\" -d '{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"net_version\",\"params\":[]}' http://localhost:9545 || exit 1"
       interval: 5s
-      timeout: 5s
+      timeout: 2s
       retries: 10000
     networks:
       - app-network
@@ -39,10 +39,10 @@ services:
       # expose the service to the host for integration testing
       - ${FUEL_CORE_HTTP_PORT:-4000}:4001
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:4001/v1/health || exit 1"]
-      interval: 10s
-      timeout: 10s
-      retries: 100
+      test: curl --fail http://localhost:4001/v1/health || exit 1
+      interval: 4s
+      timeout: 3s
+      retries: 200
     networks:
       - app-network
 

--- a/docker/fuel-core/Dockerfile
+++ b/docker/fuel-core/Dockerfile
@@ -14,9 +14,12 @@ WORKDIR /fuel
 
 COPY ./genesis_coins.json .
 
+#  Fuel Core 0.35.0, needs to be changed when core version is updated
 RUN git clone \
     https://github.com/FuelLabs/chain-configuration.git \
-    /chain-configuration
+    /chain-configuration && \
+    cd /chain-configuration && \
+    git checkout 6cea45da59bb105a02fb0b115c7ef03f3a690ba1
 
 # Copy the base local configuration
 RUN cp -R /chain-configuration/local/* ./

--- a/docker/fuel-core/fuel_core.sh
+++ b/docker/fuel-core/fuel_core.sh
@@ -16,7 +16,7 @@ fi
 
 # wait for the base layer to be up
 echo "Waiting for l1 chain."
-until curl \
+curl \
     --fail \
     --show-error \
     --silent \
@@ -24,11 +24,8 @@ until curl \
     --retry-connrefused \
     --retry $RETRIES \
     --retry-delay 1 \
-    -d "$JSON" \
-    "$L1_CHAIN_HTTP" > /dev/null; do
-    echo "Waiting for l1 chain..."
-    sleep 5
-done
+    -d $JSON \
+    $L1_CHAIN_HTTP > /dev/null
 echo "Connected to l1 chain."
 
 # get the deployments file from the deployer

--- a/docker/fuel-core/fuel_core.sh
+++ b/docker/fuel-core/fuel_core.sh
@@ -16,7 +16,7 @@ fi
 
 # wait for the base layer to be up
 echo "Waiting for l1 chain."
-curl \
+until curl \
     --fail \
     --show-error \
     --silent \
@@ -24,8 +24,11 @@ curl \
     --retry-connrefused \
     --retry $RETRIES \
     --retry-delay 1 \
-    -d $JSON \
-    $L1_CHAIN_HTTP > /dev/null
+    -d "$JSON" \
+    "$L1_CHAIN_HTTP" > /dev/null; do
+    echo "Waiting for l1 chain..."
+    sleep 5
+done
 echo "Connected to l1 chain."
 
 # get the deployments file from the deployer


### PR DESCRIPTION
- Fixes Fuel Core container waiting indefinitely
- Fixes Fuel Core using wrong chain config
- Fuel Core now waits for l1's `service_healthy` instead of `service_started`