### PR TITLE
fix: build package before publishing

### DIFF
--- a/.changeset/wet-houses-perform.md
+++ b/.changeset/wet-houses-perform.md
@@ -1,0 +1,5 @@
+---
+"@fuels/ui": patch
+---
+
+- Added pnpm build to the publish action, ensuring "dist" folder will be published

--- a/.github/workflows/release-npm-changeset.yml
+++ b/.github/workflows/release-npm-changeset.yml
@@ -50,7 +50,7 @@ jobs:
         id: changesets
         uses: FuelLabs/changesets-action@main
         with:
-          publish: pnpm changeset publish --tag next
+          publish: pnpm release
           commit: "ci(changesets): versioning packages"
           title: "ci(changesets): versioning packages"
           createGithubReleases: aggregate

--- a/.github/workflows/release-npm-changeset.yml
+++ b/.github/workflows/release-npm-changeset.yml
@@ -46,11 +46,14 @@ jobs:
           git config --global user.name "${{ github.actor }}"
           git config --global user.email "${{ github.actor }}@users.noreply.github.com"
 
+      - name: Build packages
+        run: pnpm build:lib
+
       - name: Create Release Pull Request or Publish to NPM
         id: changesets
         uses: FuelLabs/changesets-action@main
         with:
-          publish: pnpm release
+          publish: pnpm changeset publish --tag next
           commit: "ci(changesets): versioning packages"
           title: "ci(changesets): versioning packages"
           createGithubReleases: aggregate

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "node:stop": "make -C ./docker stop",
     "node:restart": "make -C ./docker restart",
     "prepare": "husky install",
-    "release": "pnpm build:lib && pnpm changeset publish --tag next",
     "start": "pnpm turbo:run start",
     "test": "pnpm turbo:run test",
     "test:all": "run-p test test:e2e",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "node:stop": "make -C ./docker stop",
     "node:restart": "make -C ./docker restart",
     "prepare": "husky install",
+    "release": "pnpm build:lib && pnpm changeset publish --tag next",
     "start": "pnpm turbo:run start",
     "test": "pnpm turbo:run test",
     "test:all": "run-p test test:e2e",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,13 +18,13 @@
   "publishConfig": {
     "access": "public",
     "main": "./dist/index.cjs.js",
-    "module": "./dist/index.cjs.js",
+    "module": "./dist/index.esm.js",
     "types": "./dist/index.d.ts",
     "typings": "./dist/index.d.ts",
     "exports": {
       ".": {
         "import": "./dist/index.esm.js",
-        "require": "./dist/index.cjs.jg",
+        "require": "./dist/index.cjs.js",
         "default": "./dist/index.cjs.js",
         "types": "./dist/index.d.ts",
         "typings": "./dist/index.d.ts"


### PR DESCRIPTION
### Context
`@fuels/ui` was being published to npm without its dist folder, after a long search I found out that `pnpm changeset publish` wasn't building the package and there were no actions in the CI's pipeline that built the package.

### This PR
- Adds `pnpm build:lib` before publishing
- Fixes a typo in the UI's package json