### PR TITLE
fix: elements position in tx component

### DIFF
--- a/packages/app-explorer/src/systems/Transaction/component/TxIcon/TxIcon.tsx
+++ b/packages/app-explorer/src/systems/Transaction/component/TxIcon/TxIcon.tsx
@@ -89,7 +89,7 @@ const styles = tv({
         icon: 'w-4 h-4',
       },
       md: {
-        root: 'w-10 h-10',
+        root: 'w-[38px] h-[38px]',
         icon: 'w-5 h-5',
       },
       lg: {

--- a/packages/app-explorer/src/systems/Transaction/component/TxOutput/styles.ts
+++ b/packages/app-explorer/src/systems/Transaction/component/TxOutput/styles.ts
@@ -5,7 +5,7 @@ export const styles = tv({
     header:
       'group gap-2 flex flex-col tablet:flex-row items-start tablet:items-center',
     amount: 'flex items-center gap-2 ml-14 tablet:ml-0',
-    content: 'gap-4 justify-between items-center flex-1',
+    content: 'gap-2 items-center flex-1',
     icon: 'transition-transform group-data-[state=closed]:hover:rotate-180 group-data-[state=open]:rotate-180',
     utxos: 'bg-gray-2 mx-4 py-3 px-4 rounded',
     contractOutputContent: [


### PR DESCRIPTION
- Closes https://github.com/FuelLabs/fuel-explorer/issues/603


- Removes flex justify-between
- Standardizes icon sizes
- Standardizes element gaps

Before:
![image](https://github.com/user-attachments/assets/7b2941a2-8698-44ea-9844-a3022b04e1c1)
After:
<img width="831" alt="image" src="https://github.com/user-attachments/assets/e76b41cb-e65c-443e-b737-da3bc84801cd">
