### PR TITLE
fix: Show 'Skipped' step only when event status is Skipped

### DIFF
--- a/packages/app-staking/src/systems/Staking/components/ClaimRewardStatusDialog/ClaimRewardStatusDialog.tsx
+++ b/packages/app-staking/src/systems/Staking/components/ClaimRewardStatusDialog/ClaimRewardStatusDialog.tsx
@@ -148,7 +148,12 @@ export const ClaimRewardStatusDialog = ({
             />
           </HStack>
           <VStack gap="0" className="overflow-y-auto max-h-[200px]">
-            {CLAIM_STEPS.map((step) => {
+            {CLAIM_STEPS.filter((step) => {
+              if (step.status === 'Skipped') {
+                return claimEvent?.status === 'Skipped';
+              }
+              return true;
+            }).map((step) => {
               const isCompleted =
                 !!statusFlags[step.status as keyof typeof statusFlags];
 

--- a/packages/app-staking/src/systems/Staking/components/RedelegateStatusDialog/RedelegateStatusDialog.tsx
+++ b/packages/app-staking/src/systems/Staking/components/RedelegateStatusDialog/RedelegateStatusDialog.tsx
@@ -148,7 +148,12 @@ export const RedelegateStatusDialog = ({
             />
           </HStack>
           <VStack gap="0" className="overflow-y-auto max-h-[200px]">
-            {REDELEGATE_STEPS.map((step) => {
+            {REDELEGATE_STEPS.filter((step) => {
+              if (step.status === 'Skipped') {
+                return redelegateEvent?.status === 'Skipped';
+              }
+              return true;
+            }).map((step) => {
               const isCompleted =
                 !!statusFlags[step.status as keyof typeof statusFlags];
 

--- a/packages/app-staking/src/systems/Staking/components/StakeStatusDialog/StakeStatusDialog.tsx
+++ b/packages/app-staking/src/systems/Staking/components/StakeStatusDialog/StakeStatusDialog.tsx
@@ -146,7 +146,12 @@ export const StakeStatusDialog = ({ identifier }: StakeStatusDialogProps) => {
             />
           </HStack>
           <VStack gap="0" className="overflow-y-auto max-h-[200px]">
-            {STAKE_STEPS.map((step) => {
+            {STAKE_STEPS.filter((step) => {
+              if (step.status === 'Skipped') {
+                return stakeEvent?.status === 'Skipped';
+              }
+              return true;
+            }).map((step) => {
               const isCompleted =
                 !!statusFlags[step.status as keyof typeof statusFlags];
 

--- a/packages/app-staking/src/systems/Staking/components/UndelegateStatusDialog/UndelegateStatusDialog.tsx
+++ b/packages/app-staking/src/systems/Staking/components/UndelegateStatusDialog/UndelegateStatusDialog.tsx
@@ -148,7 +148,12 @@ export const UndelegateStatusDialog = ({
             />
           </HStack>
           <VStack gap="0" className="overflow-y-auto max-h-[200px]">
-            {UNDELEGATE_STEPS.map((step) => {
+            {UNDELEGATE_STEPS.filter((step) => {
+              if (step.status === 'Skipped') {
+                return undelegateEvent?.status === 'Skipped';
+              }
+              return true;
+            }).map((step) => {
               const isCompleted =
                 !!statusFlags[step.status as keyof typeof statusFlags];
 

--- a/packages/app-staking/src/systems/Staking/components/WithdrawStatusDialog/WithdrawStatusDialog.tsx
+++ b/packages/app-staking/src/systems/Staking/components/WithdrawStatusDialog/WithdrawStatusDialog.tsx
@@ -157,7 +157,12 @@ export const WithdrawStatusDialog = ({
             />
           </HStack>
           <VStack gap="0" className="overflow-y-auto max-h-[200px]">
-            {WITHDRAW_STEPS.map((step) => {
+            {WITHDRAW_STEPS.filter((step) => {
+              if (step.status === GQLWithdrawStatusType.Skipped) {
+                return stakingEvent?.status === GQLWithdrawStatusType.Skipped;
+              }
+              return true;
+            }).map((step) => {
               const isCompleted =
                 !!statusFlags[step.status as keyof typeof statusFlags];
               const isCurrent = step.status === stakingEvent?.status;


### PR DESCRIPTION
# Summary
Updated status dialog components to filter and display the 'Skipped' step only if the corresponding event status is 'Skipped'. This ensures that the UI accurately reflects the current state of staking actions.
# Checklist

- [x] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [x] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [x] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [x] I've changed the Docs to reflect my changes (or it was not needed)
- [x] I've put docs links where it may be helpful (or it was not needed)
- [x] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [x] I **reviewed** the **entire PR** myself (preferably, on GH UI)
