### PR TITLE
feat: Add MaintenanceBanner and include in Layout

### DIFF
--- a/packages/app-explorer/src/systems/Core/components/Layout/Layout.tsx
+++ b/packages/app-explorer/src/systems/Core/components/Layout/Layout.tsx
@@ -2,6 +2,7 @@ import { Container, VStack, cx } from '@fuels/ui';
 import { TopNav } from '~/systems/Core/components/TopNav/TopNav';
 import HeroSection from '~/systems/Home/components/Hero/HeroSection';
 import { Footer } from '../Footer/Footer';
+import { MaintenanceBanner } from '../MaintenanceBanner/MaintenanceBanner';
 
 export type LayoutProps = {
   children: React.ReactNode;
@@ -11,6 +12,7 @@ export type LayoutProps = {
 export function Layout({ children, contentClassName }: LayoutProps) {
   return (
     <VStack className="min-w-screen" gap="0">
+      <MaintenanceBanner />
       <VStack className="min-h-screen" gap="0">
         <TopNav />
         <HeroSection />

--- a/packages/app-explorer/src/systems/Core/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/app-explorer/src/systems/Core/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -2,8 +2,28 @@
 
 import { Alert, Text } from '@fuels/ui';
 import { IconAlertTriangle } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+
+const MAINTENANCE_START = Date.UTC(2026, 3, 13, 17, 30); // April 13, 2026 17:30 UTC
+const AUTO_HIDE_AFTER_MS = 60 * 60 * 1000; // 1 hour after start time
 
 export const MaintenanceBanner = () => {
+  const [visible, setVisible] = useState(
+    () => Date.now() < MAINTENANCE_START + AUTO_HIDE_AFTER_MS,
+  );
+
+  useEffect(() => {
+    const remaining = MAINTENANCE_START + AUTO_HIDE_AFTER_MS - Date.now();
+    if (remaining <= 0) {
+      setVisible(false);
+      return;
+    }
+    const timer = setTimeout(() => setVisible(false), remaining);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
   return (
     <Alert
       color="orange"

--- a/packages/app-explorer/src/systems/Core/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/app-explorer/src/systems/Core/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Alert, Text } from '@fuels/ui';
+import { IconAlertTriangle } from '@tabler/icons-react';
+
+export const MaintenanceBanner = () => {
+  return (
+    <Alert
+      color="orange"
+      size="1"
+      variant="surface"
+      className="rounded-none justify-center"
+    >
+      <Alert.Icon>
+        <IconAlertTriangle className="text-orange-12" />
+      </Alert.Icon>
+      <Text className="text-orange-12">
+        The network is undergoing a scheduled migration today starting 17:30
+        UTC. We expect to be back up shortly.
+      </Text>
+    </Alert>
+  );
+};

--- a/packages/app-explorer/src/systems/Core/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/app-explorer/src/systems/Core/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -2,28 +2,8 @@
 
 import { Alert, Text } from '@fuels/ui';
 import { IconAlertTriangle } from '@tabler/icons-react';
-import { useEffect, useState } from 'react';
-
-const MAINTENANCE_START = Date.UTC(2026, 3, 13, 17, 30); // April 13, 2026 17:30 UTC
-const AUTO_HIDE_AFTER_MS = 60 * 60 * 1000; // 1 hour after start time
 
 export const MaintenanceBanner = () => {
-  const [visible, setVisible] = useState(
-    () => Date.now() < MAINTENANCE_START + AUTO_HIDE_AFTER_MS,
-  );
-
-  useEffect(() => {
-    const remaining = MAINTENANCE_START + AUTO_HIDE_AFTER_MS - Date.now();
-    if (remaining <= 0) {
-      setVisible(false);
-      return;
-    }
-    const timer = setTimeout(() => setVisible(false), remaining);
-    return () => clearTimeout(timer);
-  }, []);
-
-  if (!visible) return null;
-
   return (
     <Alert
       color="orange"

--- a/packages/app-explorer/src/systems/Core/components/MaintenanceBanner/MaintenanceBanner.tsx
+++ b/packages/app-explorer/src/systems/Core/components/MaintenanceBanner/MaintenanceBanner.tsx
@@ -16,7 +16,7 @@ export const MaintenanceBanner = () => {
       </Alert.Icon>
       <Text className="text-orange-12">
         The network is undergoing a scheduled migration today starting 17:30
-        UTC. We expect to be back up shortly.
+        UTC. We expect it to be up again shortly.
       </Text>
     </Alert>
   );


### PR DESCRIPTION

<img width="921" height="324" alt="image" src="https://github.com/user-attachments/assets/dc76277e-18c3-486b-8d93-1fe540596b17" />


<!--
List the issues this PR closes in a bullet list format, e.g.:
- Closes #X
- Closes FE-Z
-->

# Summary
Add a new MaintenanceBanner component that displays an orange Alert with an alert icon and a message about a scheduled network migration. Import and render the banner at the top of the Core Layout so the site shows a site-wide maintenance notice across pages.
# Checklist

- [ ] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [ ] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [ ] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [ ] I've changed the Docs to reflect my changes (or it was not needed)
- [ ] I've put docs links where it may be helpful (or it was not needed)
- [ ] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
