### PR TITLE
fix: Prevent block skipping, add stats logging and prefetch resilience

### DIFF
--- a/packages/graphql/src/application/uc/NewAddBlockRange.ts
+++ b/packages/graphql/src/application/uc/NewAddBlockRange.ts
@@ -83,10 +83,11 @@ export default class NewAddBlockRange {
     );
     const existingIds = new Set((existingRows as any[]).map((r) => r._id));
 
-    let highestCommitted: number | null = null;
+    let highestSeen: number | null = null;
 
     for (const blockData of blocksData) {
       const block = new Block({ data: blockData });
+      highestSeen = block.id;
 
       if (existingIds.has(block.id)) continue;
 
@@ -252,13 +253,12 @@ export default class NewAddBlockRange {
       });
       logger.debug('Consumer', `Persisting block: ${block.id}`);
       await connection.executeTransaction(queries);
-      highestCommitted = block.id;
       logger.debug('Consumer', `Persisted block: ${block.id}`);
     }
     const end = performance.now();
     const secs = Number.parseInt(`${(end - start) / 1000}`);
     logger.debug('Consumer', `Synced blocks: #${from} - #${to} (${secs}s)`);
-    return highestCommitted;
+    return highestSeen;
   }
 
   async getBlocks(from: number, to: number): Promise<GQLBlock[]> {

--- a/packages/graphql/src/syncer.ts
+++ b/packages/graphql/src/syncer.ts
@@ -48,6 +48,10 @@ async function main() {
   }> | null = null;
   let heightPromise: Promise<number | null> = fetchLatestHeight();
 
+  let statsBlockCount = 0;
+  let statsStartTime = Date.now();
+  const STATS_INTERVAL_MS = 30_000;
+
   function startPrefetch(from: number, to: number) {
     const p = Promise.race([
       addBlockRange.getBlocks(from, to).then((blocks) => {
@@ -127,10 +131,12 @@ async function main() {
         if (idx === 0 && prefetchedBlocks) {
           const p = prefetchedBlocks;
           prefetchedBlocks = null;
-          const prefetched = await p;
-          if (prefetched.from === event.from && prefetched.to >= event.to) {
-            return prefetched;
-          }
+          try {
+            const prefetched = await p;
+            if (prefetched.from === event.from && prefetched.to >= event.to) {
+              return prefetched;
+            }
+          } catch {}
         }
         return startPrefetch(event.from, event.to);
       });
@@ -169,7 +175,9 @@ async function main() {
         if (results[j].status === 'fulfilled') {
           const highest = (results[j] as PromiseFulfilledResult<number | null>)
             .value;
+          const prevCursor = cursor;
           if (!hasFailure) cursor = highest ?? chunk[j].to;
+          statsBlockCount += cursor - prevCursor;
         } else {
           hasFailure = true;
           const err = (results[j] as PromiseRejectedResult).reason;
@@ -180,6 +188,19 @@ async function main() {
           );
         }
       }
+
+      const now = Date.now();
+      if (now - statsStartTime >= STATS_INTERVAL_MS) {
+        const elapsed = (now - statsStartTime) / 1000;
+        const bps = (statsBlockCount / elapsed).toFixed(1);
+        logger.info(
+          'Syncer',
+          `[stats] blocks=${statsBlockCount} elapsed=${elapsed.toFixed(0)}s throughput=${bps} blocks/sec cursor=${cursor} behind=${height - cursor}`,
+        );
+        statsBlockCount = 0;
+        statsStartTime = now;
+      }
+
       if (hasFailure) {
         await setTimeout(2000);
         failed = true;


### PR DESCRIPTION
Follow-up to #680 — these fixes were pushed after the merge.

### Changes

- **Fix block skipping**: cursor now tracks the highest block *seen* (not just committed). Previously, if Fuel Core returned fewer blocks than requested (race between height check and block fetch), the cursor would advance past unfetched blocks permanently.
- **Prefetch resilience**: speculative prefetch failures now gracefully fall through to a fresh fetch instead of failing the entire batch.
- **Stats logging**: adds a `[stats]` log line every 30s with throughput, cursor position, and blocks behind — for monitoring deployed performance.

### Verified locally
- 2,769 blocks with zero gaps after catch-up + 5 min soak
- 479 blocks with 17 timeout errors, all recovered cleanly