### PR TITLE
fix: Remove block fetch timeout that blocks mainnet syncing

### DIFF
--- a/packages/graphql/src/syncer.ts
+++ b/packages/graphql/src/syncer.ts
@@ -50,7 +50,22 @@ async function main() {
 
   let statsBlockCount = 0;
   let statsStartTime = Date.now();
+  let lastKnownHeight = 0;
   const STATS_INTERVAL_MS = 30_000;
+
+  function emitStats() {
+    const now = Date.now();
+    if (now - statsStartTime < STATS_INTERVAL_MS) return;
+    const elapsed = (now - statsStartTime) / 1000;
+    const bps = (statsBlockCount / elapsed).toFixed(1);
+    const behind = lastKnownHeight > cursor ? lastKnownHeight - cursor : 0;
+    logger.info(
+      'Syncer',
+      `[stats] blocks=${statsBlockCount} elapsed=${elapsed.toFixed(0)}s throughput=${bps} blocks/sec cursor=${cursor} behind=${behind}`,
+    );
+    statsBlockCount = 0;
+    statsStartTime = now;
+  }
 
   function startPrefetch(from: number, to: number) {
     const p = addBlockRange.getBlocks(from, to).then((blocks) => {
@@ -61,6 +76,7 @@ async function main() {
   }
 
   while (true) {
+    emitStats();
     const startTime = Date.now();
     let height: number;
     try {
@@ -80,6 +96,7 @@ async function main() {
       logger.debug('Syncer', `Fuel core response time: ${latencyMs}ms`);
       backoffMs = BACKOFF_INITIAL_MS;
       height = result;
+      lastKnownHeight = height;
     } catch (e: any) {
       const latencyMs = Date.now() - startTime;
       logger.error(
@@ -182,18 +199,6 @@ async function main() {
             `Failed batch #${chunk[j].from}-#${chunk[j].to}${is429 ? ' (rate limited)' : ''}: ${err?.message}`,
           );
         }
-      }
-
-      const now = Date.now();
-      if (now - statsStartTime >= STATS_INTERVAL_MS) {
-        const elapsed = (now - statsStartTime) / 1000;
-        const bps = (statsBlockCount / elapsed).toFixed(1);
-        logger.info(
-          'Syncer',
-          `[stats] blocks=${statsBlockCount} elapsed=${elapsed.toFixed(0)}s throughput=${bps} blocks/sec cursor=${cursor} behind=${height - cursor}`,
-        );
-        statsBlockCount = 0;
-        statsStartTime = now;
       }
 
       if (hasFailure) {

--- a/packages/graphql/src/syncer.ts
+++ b/packages/graphql/src/syncer.ts
@@ -53,14 +53,9 @@ async function main() {
   const STATS_INTERVAL_MS = 30_000;
 
   function startPrefetch(from: number, to: number) {
-    const p = Promise.race([
-      addBlockRange.getBlocks(from, to).then((blocks) => {
-        return { blocks, from, to };
-      }),
-      setTimeout(FUEL_CORE_TIMEOUT_MS).then(() => {
-        throw new Error(`Block fetch timeout #${from}-#${to}`);
-      }),
-    ]);
+    const p = addBlockRange.getBlocks(from, to).then((blocks) => {
+      return { blocks, from, to };
+    });
     p.catch(() => {});
     return p;
   }


### PR DESCRIPTION
Urgent fix — the 5s block fetch timeout added in #681 is killing mainnet syncing.

### Problem

Mainnet Fuel Core is unhealthy 87% of the time and responses regularly take 1-5s. The 5s timeout on `startPrefetch` causes every block fetch to fail, dropping throughput from 1.5 to 0.4 blocks/sec. The syncer gap grew from 185 to 1500+ blocks in 15 minutes.

### Fix

Remove the timeout from block fetches. The height check retains its 5s timeout (lightweight query). Block fetches are handled by `Promise.allSettled` + retry logic which already recovers from failures.

### Metrics

| Metric | Baseline (pre-#680) | With timeout (#681) | 
|--------|---------------------|---------------------|
| Avg gap | 185 blocks | 1300+ blocks (growing) |
| Throughput | 1.5 blocks/sec | 0.4 blocks/sec |
| Fuel Core healthy | 15% | 13% |