### PR TITLE
fix: Reduce batch size to 2 blocks per request

### DIFF
--- a/packages/graphql/src/syncer.ts
+++ b/packages/graphql/src/syncer.ts
@@ -9,7 +9,7 @@ import BlockDAO from './infra/dao/BlockDAO';
 const FUEL_CORE_TIMEOUT_MS = 5000;
 const BACKOFF_INITIAL_MS = 1000;
 const BACKOFF_MAX_MS = 5000;
-const BATCH_SIZE = 10;
+const BATCH_SIZE = 2;
 const MAX_RANGE = 1000;
 const CONCURRENCY = 10;
 


### PR DESCRIPTION
Reduces Fuel Core load by fetching 2 blocks per request instead of 10.

With CONCURRENCY=10, the syncer still fires 10 parallel requests — but each one is 5x lighter. Local benchmarks against mainnet:

| Batch size | Throughput |
|------------|-----------|
| 10 | 11.7 blocks/sec |
| 5 | 13.9 blocks/sec |
| 2 | 15.7 blocks/sec |
| 1 | 17.5 blocks/sec |

BATCH_SIZE=2 balances throughput (15.7) with round-trip overhead.