### PR TITLE
chore: drop unused redundant indexes

### DIFF
--- a/packages/graphql/database/migrations/049_drop_unused_redundant_indexes.sql
+++ b/packages/graphql/database/migrations/049_drop_unused_redundant_indexes.sql
@@ -1,0 +1,25 @@
+-- Migration 049: Drop unused redundant indexes
+--
+-- Each index below has 0 (or 1) scans in pg_stat_user_indexes, is not backed
+-- by a UNIQUE/PK constraint, and is either an exact-column duplicate of
+-- another index or fully covered as a leading-column prefix of a wider
+-- composite. Dropping them changes no current query plan and removes the
+-- corresponding write amplification.
+
+-- Non-unique duplicate of UNIQUE blocks_id_key (constraint).
+DROP INDEX CONCURRENTLY IF EXISTS indexer.blocks_id_idx1;
+
+-- Single-column (_id) covered by leading column of the composite PK
+-- (_id, block_id, tx_hash, account_hash).
+DROP INDEX CONCURRENTLY IF EXISTS indexer.transactions_accounts__id_idx;
+
+-- Non-unique duplicate of inputs_pkey on (_id).
+DROP INDEX CONCURRENTLY IF EXISTS indexer.inputs__id_idx1;
+
+-- Single-column (tx_hash) covered by leading column of the composite UNIQUE
+-- balance_tx_hash_account_hash_asset_id_idx (tx_hash, account_hash, asset_id).
+DROP INDEX CONCURRENTLY IF EXISTS indexer.balance_tx_hash_idx;
+
+-- Identical column definition to balance_account_asset_id_idx2
+-- (account_hash, asset_id, _id DESC); the latter is the one in active use.
+DROP INDEX CONCURRENTLY IF EXISTS indexer.balance_account_hash_asset_id__id_idx;


### PR DESCRIPTION
## Summary

Drops 5 redundant/unused indexes from production tables (~422 GB on mainnet). Each is either an exact-column duplicate of another index or fully covered by a wider composite, with `idx_scan <= 1` in `pg_stat_user_indexes`. None backs a `UNIQUE`/`PK` constraint or an FK enforcement.

| Table | Index | Prod size | Reason kept |
|---|---|---|---|
| blocks | `blocks_id_idx1` | 6.3 GB | dup of `blocks_id_key` (UNIQUE constraint) |
| transactions_accounts | `transactions_accounts__id_idx` | 66 GB | covered by leading column of composite PK |
| inputs | `inputs__id_idx1` | 105 GB | dup of `inputs_pkey` |
| balance | `balance_tx_hash_idx` | 48 GB | covered by leading column of `balance_tx_hash_account_hash_asset_id_idx` |
| balance | `balance_account_hash_asset_id__id_idx` | 197 GB | identical-column dup of `balance_account_asset_id_idx2` |

Reduces write amplification on the heavy-write tables (every INSERT into these tables currently maintains the redundant indexes for no benefit).

All drops use `DROP INDEX CONCURRENTLY IF EXISTS` — no read/write blocking. Reversible via `CREATE INDEX CONCURRENTLY` if regression observed.

## Test plan

- [ ] `pnpm db:migrate:dry` shows the migration as pending
- [ ] On a non-prod env: `pnpm db:migrate` runs cleanly; the 5 indexes are gone
- [ ] On prod: pre/post `\d+` of each table shows the listed indexes are removed and no others
- [ ] No regression in API p99 latency 24h after applying