### PR TITLE
chore: tune autovacuum thresholds for large tables

### DIFF
--- a/packages/graphql/database/migrations/050_tune_autovacuum_large_tables.sql
+++ b/packages/graphql/database/migrations/050_tune_autovacuum_large_tables.sql
@@ -1,0 +1,31 @@
+-- Migration 050: Tune autovacuum thresholds for large tables
+--
+-- The default autovacuum scale factors (vacuum=0.1, analyze=0.05) require
+-- autovacuum to wait for ~10% of the table to change before vacuuming and ~5%
+-- before analyzing. On tables with hundreds of millions to billions of rows
+-- this means autovacuum and autoanalyze rarely (or never) fire on the normal
+-- write churn pattern, leaving stats stale and dead tuples accumulating.
+--
+-- Per-table overrides below scale the trigger thresholds proportionally to
+-- table size so they fire on a more reasonable absolute change.
+
+-- 1.92B rows; default analyze trigger ~96M rows of churn.
+ALTER TABLE indexer.transactions_accounts
+  SET (autovacuum_vacuum_scale_factor = 0.005,
+       autovacuum_analyze_scale_factor = 0.001);
+
+-- 5.01B rows; default analyze trigger ~250M rows of churn.
+ALTER TABLE indexer.inputs
+  SET (autovacuum_vacuum_scale_factor = 0.005,
+       autovacuum_analyze_scale_factor = 0.001);
+
+-- 548M rows; default analyze trigger ~27M rows of churn.
+ALTER TABLE indexer.transactions
+  SET (autovacuum_vacuum_scale_factor = 0.005,
+       autovacuum_analyze_scale_factor = 0.001);
+
+-- 462M rows with steady UPDATE churn (1%+ dead tuples observed); slightly
+-- looser than the insert-mostly tables above.
+ALTER TABLE indexer.balance
+  SET (autovacuum_vacuum_scale_factor = 0.01,
+       autovacuum_analyze_scale_factor = 0.005);


### PR DESCRIPTION
## Summary

Per-table autovacuum overrides on the four largest indexer tables. The default scale factors (vacuum=0.1, analyze=0.05) require ~10%/5% of a table to change before autovacuum/autoanalyze fires; on B-row tables that means autovacuum effectively never runs at the syncer's normal write rate, leaving stats stale enough to cause bad query plans.

| Table | Live rows | Default analyze trigger | New analyze trigger |
|---|---|---|---|
| transactions_accounts | 1.92 B | ~96 M | ~1.92 M |
| inputs | 5.01 B | ~250 M | ~5 M |
| transactions | 548 M | ~27 M | ~548 K |
| balance | 462 M | ~23 M | ~2.3 M |

`ALTER TABLE … SET (…)` only updates pg_class reloptions — no table rewrite, no read/write blocking beyond a brief catalog AccessExclusiveLock.

## Test plan

- [ ] `pnpm db:migrate:dry` shows the migration as pending
- [ ] On non-prod: `pnpm db:migrate` runs cleanly; `\d+ indexer.<table>` shows the new options
- [ ] On prod: 24h after applying, `pg_stat_user_tables` shows non-empty `last_autoanalyze` for all 4 tables