### PR TITLE
fix: Backfill broken block data on syncer startup (FE-1814)

### DIFF
--- a/packages/graphql/scripts/run.sh
+++ b/packages/graphql/scripts/run.sh
@@ -4,8 +4,8 @@ if [ "$1" = "api" ]; then
     echo "Running API"  
     pnpm start:api
 elif [ "$1" = "syncer" ]; then
-    echo "Running backfill (one-shot, no-op if clean)"
-    npx tsx src/backfill.ts || echo "Backfill failed, continuing..."
+    echo "Running backfill in background (no-op if clean)"
+    npx tsx src/backfill.ts &
     echo "Running Syncer"
     pnpm start:syncer
 fi

--- a/packages/graphql/scripts/run.sh
+++ b/packages/graphql/scripts/run.sh
@@ -4,6 +4,8 @@ if [ "$1" = "api" ]; then
     echo "Running API"  
     pnpm start:api
 elif [ "$1" = "syncer" ]; then
+    echo "Running backfill (one-shot, no-op if clean)"
+    npx tsx src/backfill.ts || echo "Backfill failed, continuing..."
     echo "Running Syncer"
     pnpm start:syncer
 fi

--- a/packages/graphql/src/application/uc/backfill.test.ts
+++ b/packages/graphql/src/application/uc/backfill.test.ts
@@ -1,20 +1,22 @@
 import { execSync } from 'node:child_process';
-import path from 'node:path';
+
+const BACKFILL_CMD = 'npx tsx src/backfill.ts';
+const BACKFILL_ENV = {
+  ...process.env,
+  DB_HOST: '127.0.0.1',
+  DB_PORT: '5435',
+  DB_USER: 'postgres',
+  DB_PASS: 'postgres',
+  DB_NAME: 'postgres',
+  FUEL_PROVIDER: 'https://mainnet.fuel.network/v1/graphql',
+};
 
 describe('Backfill script', () => {
   it('exits cleanly when no broken blocks exist', () => {
-    const backfillPath = path.resolve(__dirname, '../../backfill.ts');
-    const result = execSync(`npx tsx ${backfillPath}`, {
+    const result = execSync(BACKFILL_CMD, {
       timeout: 15000,
-      env: {
-        ...process.env,
-        DB_HOST: '127.0.0.1',
-        DB_PORT: '5435',
-        DB_USER: 'postgres',
-        DB_PASS: 'postgres',
-        DB_NAME: 'postgres',
-        FUEL_PROVIDER: 'https://mainnet.fuel.network/v1/graphql',
-      },
+      cwd: `${__dirname}/../..`,
+      env: BACKFILL_ENV,
       encoding: 'utf-8',
     });
 
@@ -22,20 +24,12 @@ describe('Backfill script', () => {
   });
 
   it('exits within 10 seconds when clean', () => {
-    const backfillPath = path.resolve(__dirname, '../../backfill.ts');
     const start = Date.now();
 
-    execSync(`npx tsx ${backfillPath}`, {
+    execSync(BACKFILL_CMD, {
       timeout: 10000,
-      env: {
-        ...process.env,
-        DB_HOST: '127.0.0.1',
-        DB_PORT: '5435',
-        DB_USER: 'postgres',
-        DB_PASS: 'postgres',
-        DB_NAME: 'postgres',
-        FUEL_PROVIDER: 'https://mainnet.fuel.network/v1/graphql',
-      },
+      cwd: `${__dirname}/../..`,
+      env: BACKFILL_ENV,
       encoding: 'utf-8',
     });
 

--- a/packages/graphql/src/application/uc/backfill.test.ts
+++ b/packages/graphql/src/application/uc/backfill.test.ts
@@ -1,0 +1,45 @@
+import { execSync } from 'node:child_process';
+import path from 'node:path';
+
+describe('Backfill script', () => {
+  it('exits cleanly when no broken blocks exist', () => {
+    const backfillPath = path.resolve(__dirname, '../../backfill.ts');
+    const result = execSync(`npx tsx ${backfillPath}`, {
+      timeout: 15000,
+      env: {
+        ...process.env,
+        DB_HOST: '127.0.0.1',
+        DB_PORT: '5435',
+        DB_USER: 'postgres',
+        DB_PASS: 'postgres',
+        DB_NAME: 'postgres',
+        FUEL_PROVIDER: 'https://mainnet.fuel.network/v1/graphql',
+      },
+      encoding: 'utf-8',
+    });
+
+    expect(result).toContain('No broken blocks found');
+  });
+
+  it('exits within 10 seconds when clean', () => {
+    const backfillPath = path.resolve(__dirname, '../../backfill.ts');
+    const start = Date.now();
+
+    execSync(`npx tsx ${backfillPath}`, {
+      timeout: 10000,
+      env: {
+        ...process.env,
+        DB_HOST: '127.0.0.1',
+        DB_PORT: '5435',
+        DB_USER: 'postgres',
+        DB_PASS: 'postgres',
+        DB_NAME: 'postgres',
+        FUEL_PROVIDER: 'https://mainnet.fuel.network/v1/graphql',
+      },
+      encoding: 'utf-8',
+    });
+
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(10000);
+  });
+});

--- a/packages/graphql/src/application/uc/syncer.test.ts
+++ b/packages/graphql/src/application/uc/syncer.test.ts
@@ -1,0 +1,90 @@
+import { GraphQLClient } from 'graphql-request';
+import { getSdk } from '~/graphql/generated/sdk-provider';
+
+const FUEL_PROVIDER = 'https://mainnet.fuel.network/v1/graphql';
+
+function collectKeys(obj: any, prefix = ''): Set<string> {
+  const keys = new Set<string>();
+  if (obj === null || obj === undefined || typeof obj !== 'object') return keys;
+  if (Array.isArray(obj)) {
+    for (const item of obj) {
+      for (const k of collectKeys(item, prefix)) keys.add(k);
+    }
+    return keys;
+  }
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    keys.add(path);
+    for (const k of collectKeys(value, path)) keys.add(k);
+  }
+  return keys;
+}
+
+describe('Syncer data completeness', () => {
+  const gqlClient = new GraphQLClient(FUEL_PROVIDER);
+  const sdk = getSdk(gqlClient);
+
+  it('syncer stores all fields the frontend expects from blocks.data JSONB', async () => {
+    const result = await sdk.blocks({ last: 1 });
+    const block = result.data.blocks.nodes[0];
+
+    const keys = collectKeys(block);
+
+    const requiredFields = [
+      'height',
+      'id',
+      'header.height',
+      'header.applicationHash',
+      'header.daHeight',
+      'header.time',
+      'header.transactionsCount',
+      'consensus.__typename',
+    ];
+
+    const requiredTxFields = [
+      'id',
+      'rawPayload',
+      'scriptData',
+      'inputs',
+      'outputs',
+      'status.__typename',
+    ];
+
+    const missingBlock: string[] = [];
+    for (const field of requiredFields) {
+      if (!keys.has(field)) missingBlock.push(field);
+    }
+
+    if (block.transactions?.length > 0) {
+      const txKeys = collectKeys(block.transactions[0]);
+      const missingTx: string[] = [];
+      for (const field of requiredTxFields) {
+        if (!txKeys.has(field)) missingTx.push(field);
+      }
+      if (missingTx.length > 0) {
+        console.log('Missing transaction fields:', missingTx);
+      }
+      expect(missingTx).toEqual([]);
+    }
+
+    if (missingBlock.length > 0) {
+      console.log('Missing block fields:', missingBlock);
+    }
+    expect(missingBlock).toEqual([]);
+  }, 30000);
+
+  it('SDK blocks query returns InputCoin.predicateData (non-null in schema)', async () => {
+    const result = await sdk.blocks({ last: 5 });
+    for (const block of result.data.blocks.nodes) {
+      for (const tx of block.transactions) {
+        if (!tx.inputs) continue;
+        for (const input of tx.inputs) {
+          if (input.__typename === 'InputCoin') {
+            expect(input).toHaveProperty('predicateData');
+            expect(input).toHaveProperty('predicateGasUsed');
+          }
+        }
+      }
+    }
+  }, 30000);
+});

--- a/packages/graphql/src/backfill.ts
+++ b/packages/graphql/src/backfill.ts
@@ -1,0 +1,123 @@
+import { logger } from './core/Logger';
+import { client } from './graphql/GraphQLSDK';
+import { DatabaseConnection } from './infra/database/DatabaseConnection';
+
+const RANGE_START = 52734751;
+const RANGE_END = 52758580;
+const CHUNK_SIZE = 10;
+const CONCURRENCY = 5;
+
+async function hydrateAndUpdate(connection: DatabaseConnection, blocks: any[]) {
+  for (const block of blocks) {
+    const height = Number(block.header.height);
+
+    // Hydrate status.block on each transaction (same as syncer does)
+    for (const transaction of block.transactions) {
+      if (!transaction.status) continue;
+      if (
+        ['FailureStatus', 'SuccessStatus'].includes(
+          transaction.status.__typename,
+        )
+      ) {
+        transaction.status.block = {
+          ...block,
+          transactions: [],
+          transactionIds: [],
+        };
+      }
+    }
+    (block as any).transactionIds = block.transactions.map((t: any) => t.id);
+
+    const queries: { statement: string; params: any }[] = [
+      {
+        statement:
+          "UPDATE indexer.blocks SET data = $1 WHERE _id = $2 AND NOT (data ? 'height')",
+        params: [block, height],
+      },
+      ...block.transactions.map((tx: any) => ({
+        statement:
+          'UPDATE indexer.transactions SET data = $1 WHERE tx_hash = $2',
+        params: [tx, tx.id],
+      })),
+    ];
+
+    await connection.executeTransaction(queries);
+  }
+}
+
+async function main() {
+  const connection = DatabaseConnection.getInstance();
+
+  const broken = await connection.query(
+    "SELECT count(*)::int as cnt FROM indexer.blocks WHERE _id BETWEEN $1 AND $2 AND NOT (data ? 'height')",
+    [RANGE_START, RANGE_END],
+  );
+  const brokenCount = broken[0]?.cnt ?? 0;
+  if (brokenCount === 0) {
+    logger.info('Backfill', 'No broken blocks found, skipping.');
+    process.exit(0);
+  }
+
+  logger.info('Backfill', `Found ${brokenCount} broken blocks, backfilling...`);
+
+  const total = RANGE_END - RANGE_START + 1;
+  let processed = 0;
+  let updated = 0;
+
+  for (
+    let cursor = RANGE_START;
+    cursor <= RANGE_END;
+    cursor += CHUNK_SIZE * CONCURRENCY
+  ) {
+    const fetches = [];
+    for (let c = 0; c < CONCURRENCY; c++) {
+      const from = cursor + c * CHUNK_SIZE;
+      if (from > RANGE_END) break;
+      const size = Math.min(CHUNK_SIZE, RANGE_END - from + 1);
+      fetches.push(
+        client.sdk
+          .blocks({ after: String(from - 1), first: size })
+          .then((res) => res.data.blocks.nodes)
+          .catch((e) => {
+            logger.error('Backfill', `Fetch failed at ${from}: ${e.message}`);
+            return [];
+          }),
+      );
+    }
+
+    const results = await Promise.all(fetches);
+    for (const blocks of results) {
+      if (blocks.length === 0) continue;
+      await hydrateAndUpdate(connection, blocks as any[]);
+      updated += blocks.length;
+    }
+
+    processed += CHUNK_SIZE * CONCURRENCY;
+    const pct = Math.min(100, (processed / total) * 100).toFixed(1);
+    logger.info(
+      'Backfill',
+      `Progress: ${pct}% (${updated} blocks updated, cursor=${cursor + CHUNK_SIZE * CONCURRENCY})`,
+    );
+  }
+
+  // Verify
+  const remaining = await connection.query(
+    "SELECT count(*) as cnt FROM indexer.blocks WHERE _id BETWEEN $1 AND $2 AND NOT (data ? 'height')",
+    [RANGE_START, RANGE_END],
+  );
+  const cnt = remaining[0]?.cnt ?? 0;
+  if (cnt > 0) {
+    logger.warn(
+      'Backfill',
+      `${cnt} broken blocks remain — will retry on next restart`,
+    );
+  } else {
+    logger.info('Backfill', 'Complete. All blocks fixed.');
+  }
+  process.exit(0);
+}
+
+main().catch((e) => {
+  logger.error('Backfill', `Error: ${e.message} — will retry on next restart`);
+  process.exit(0);
+});

--- a/packages/graphql/src/backfill.ts
+++ b/packages/graphql/src/backfill.ts
@@ -102,7 +102,7 @@ async function main() {
 
   // Verify
   const remaining = await connection.query(
-    "SELECT count(*) as cnt FROM indexer.blocks WHERE _id BETWEEN $1 AND $2 AND NOT (data ? 'height')",
+    "SELECT count(*)::int as cnt FROM indexer.blocks WHERE _id BETWEEN $1 AND $2 AND NOT (data ? 'height')",
     [RANGE_START, RANGE_END],
   );
   const cnt = remaining[0]?.cnt ?? 0;
@@ -119,5 +119,5 @@ async function main() {
 
 main().catch((e) => {
   logger.error('Backfill', `Error: ${e.message} — will retry on next restart`);
-  process.exit(0);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary

PR #683 stripped fields from the syncer's GraphQL query that the frontend reads from stored JSONB. ~24k blocks have incomplete data causing block-detail and tx-detail pages to error.

This adds a self-healing backfill that runs automatically on syncer startup:
- Checks for broken blocks in range 52,734,751 - 52,758,580 (single COUNT query)
- If found, re-fetches from Fuel Core and UPDATEs only the `data` JSONB columns
- Hydrates `status.block` on transactions (same as the syncer's normal path)
- Skips already-fixed rows via `WHERE NOT (data ? 'height')`
- No INSERTs, no aggregate side effects, fully re-runnable
- No-op once all blocks are clean — adds zero overhead to normal startup

## Tested locally
- Seeded 5 blocks with incomplete JSONB, verified backfill fixed them with real Fuel Core data
- Verified second startup skips backfill (no broken blocks found)
- Verified syncer enters normal loop after backfill completes

Closes FE-1814