### PR TITLE
fix: cut explorer dashboard query cost

### DIFF
--- a/packages/graphql/src/graphql/resolvers/BlockResolver.ts
+++ b/packages/graphql/src/graphql/resolvers/BlockResolver.ts
@@ -170,7 +170,8 @@ export class BlockResolver {
     const cachedTps = DataCache.getInstance().get('tps');
     if (cachedTps) return cachedTps;
     const blockDAO = new BlockDAO();
-    const tps = await blockDAO.tps();
+    const maxTs = await blockDAO.getMaxTimestamp();
+    const tps = await blockDAO.tps(maxTs);
     DataCache.getInstance().save('tps', 60000, tps);
     return tps;
   }
@@ -207,28 +208,20 @@ export class BlockResolver {
     if (cachedTps) return cachedTps;
     const blockDAO = new BlockDAO();
 
-    // Parallel execution of all database queries
-    const [
-      totalTps,
-      averageTps,
-      maxTps,
-      averageTpsPerMinute,
-      rollingStats60s,
-      totalGasUsed,
-      averageGasUsed,
-      maxGasUsed,
-      totalFee,
-    ] = await Promise.all([
-      blockDAO.getTotalTps(),
-      blockDAO.getAverageTps(),
-      blockDAO.getMaxTps(),
-      blockDAO.getAverageTpsPerMinute(),
-      blockDAO.getRollingStats60s(),
-      blockDAO.getTotalGasUsed(),
-      blockDAO.getAverageGasUsed(),
-      blockDAO.getMaxGasUsed(),
-      blockDAO.getTotalFee() as any,
-    ]);
+    // Pin the analytics window to a single MAX(timestamp) lookup so all
+    // downstream queries share the same anchor (consistent snapshot) AND so
+    // the value can be passed as a bound parameter — that's what lets the
+    // planner pick an Index Scan on blocks_timestamp_idx instead of a
+    // Parallel Seq Scan over the whole blocks table.
+    const maxTs = await blockDAO.getMaxTimestamp();
+
+    const [hourly, averageTpsPerMinute, rollingStats60s, totalFee] =
+      await Promise.all([
+        blockDAO.getHourlyStatistics(maxTs),
+        blockDAO.getAverageTpsPerMinute(maxTs),
+        blockDAO.getRollingStats60s(maxTs),
+        blockDAO.getTotalFee() as any,
+      ]);
 
     let totalFee24hrs = 0;
     for (const fee of totalFee) {
@@ -246,14 +239,14 @@ export class BlockResolver {
 
     const statistics = {
       nodes: {
-        totalTps,
-        averageTps,
-        maxTps,
+        totalTps: hourly.totalTps,
+        averageTps: hourly.averageTps,
+        maxTps: hourly.maxTps,
         averageTpsPerMinute,
         rollingStats60s,
-        totalGasUsed,
-        averageGasUsed,
-        maxGasUsed,
+        totalGasUsed: hourly.totalGasUsed,
+        averageGasUsed: hourly.averageGasUsed,
+        maxGasUsed: hourly.maxGasUsed,
         totalFee,
         totalFee24hrs: totalFee24hrsInUsd,
       },

--- a/packages/graphql/src/infra/dao/BlockDAO.ts
+++ b/packages/graphql/src/infra/dao/BlockDAO.ts
@@ -161,26 +161,33 @@ export default class BlockDAO {
     };
   }
 
-  async tps() {
+  // The window-anchor `MAX("timestamp")` is computed once via getMaxTimestamp()
+  // and passed in as $1. Embedding the subquery turned the WHERE filter into a
+  // runtime parameter the planner can't size, which made it pick a Parallel Seq
+  // Scan over the whole 50M-row blocks table. With $1 bound to a literal, the
+  // planner uses the histogram on `timestamp` and picks an Index Scan on
+  // blocks_timestamp_idx that touches only the recent ~89K rows.
+
+  async getMaxTimestamp(): Promise<Date | null> {
+    const [row] = await this.databaseConnection.query(
+      'SELECT MAX("timestamp") AS max_ts FROM indexer.blocks',
+      [],
+    );
+    return row?.max_ts ?? null;
+  }
+
+  async tps(maxTs: Date | null) {
+    if (!maxTs) return { nodes: [] };
     const data = await this.databaseConnection.query(
-      `SELECT to_char(hour, 'YYYY-MM-DD HH24') AS date,
+      `SELECT to_char(date_trunc('hour', "timestamp"), 'YYYY-MM-DD HH24') AS date,
         SUM(transactions_count) AS total_tps,
         SUM(gas_used::int) AS total_gas_used
-      FROM (
-        SELECT date_trunc('hour', "timestamp") AS hour,
-          transactions_count,
-          gas_used
-        FROM indexer.blocks
-        WHERE "timestamp" > date_trunc('hour', (
-          SELECT MAX("timestamp") FROM indexer.blocks
-        )) - interval '24 hours'
-        AND "timestamp" < date_trunc('hour', (
-          SELECT MAX("timestamp") FROM indexer.blocks
-        ))
-      ) t
-      GROUP BY hour
-      ORDER BY hour ASC`,
-      [],
+      FROM indexer.blocks
+      WHERE "timestamp" >  date_trunc('hour', $1::timestamptz) - INTERVAL '24 hours'
+        AND "timestamp" <  date_trunc('hour', $1::timestamptz)
+      GROUP BY 1
+      ORDER BY 1 ASC`,
+      [maxTs],
     );
     const intervals = [];
     for (const row of data) {
@@ -203,87 +210,61 @@ export default class BlockDAO {
     };
   }
 
-  async getAverageTps() {
-    const data = await this.databaseConnection.query(
-      `SELECT to_char(hour, 'YYYY-MM-DD HH24') AS date,
-        avg(transactions_count) AS value
-      FROM (
-        SELECT date_trunc('hour', "timestamp") AS hour,
-          transactions_count
-        FROM indexer.blocks
-        WHERE "timestamp" > date_trunc('hour', (
-          SELECT MAX("timestamp") FROM indexer.blocks
-        )) - interval '24 hours'
-      ) t
-      GROUP BY hour
-      ORDER BY hour`,
-      [],
+  // Single scan that emits all six per-hour aggregates the dashboard needs.
+  // Replaces six individual queries (getTotalTps/getAverageTps/getMaxTps and
+  // their gas equivalents) which were each doing the same 24h scan.
+  async getHourlyStatistics(maxTs: Date | null) {
+    const empty = {
+      totalTps: [],
+      averageTps: [],
+      maxTps: [],
+      totalGasUsed: [],
+      averageGasUsed: [],
+      maxGasUsed: [],
+    };
+    if (!maxTs) return empty;
+    const rows = await this.databaseConnection.query(
+      `SELECT to_char(date_trunc('hour', "timestamp"), 'YYYY-MM-DD HH24') AS date,
+        SUM(transactions_count)::numeric AS sum_txs,
+        AVG(transactions_count)::numeric AS avg_txs,
+        MAX(transactions_count)::numeric AS max_txs,
+        SUM(gas_used::numeric) AS sum_gas,
+        AVG(gas_used::numeric) AS avg_gas,
+        MAX(gas_used::numeric) AS max_gas
+      FROM indexer.blocks
+      WHERE "timestamp" > date_trunc('hour', $1::timestamptz) - INTERVAL '24 hours'
+      GROUP BY 1
+      ORDER BY 1`,
+      [maxTs],
     );
-    return data.map((row) => ({
-      date: dayjs(row.date).startOf('hour').utcOffset(0, true).toDate(),
-      value: Number(row.value),
-    }));
+    const toBucket = (col: string) =>
+      rows.map((r: any) => ({
+        date: dayjs(r.date).startOf('hour').utcOffset(0, true).toDate(),
+        value: Number(r[col]),
+      }));
+    // The legacy getMaxTps used a 23-hour window (vs 24h here); preserve the
+    // historical entry count to keep any external SDK consumer's expectations
+    // intact.
+    return {
+      totalTps: toBucket('sum_txs'),
+      averageTps: toBucket('avg_txs'),
+      maxTps: toBucket('max_txs').slice(-24),
+      totalGasUsed: toBucket('sum_gas'),
+      averageGasUsed: toBucket('avg_gas'),
+      maxGasUsed: toBucket('max_gas'),
+    };
   }
 
-  async getTotalTps() {
+  async getAverageTpsPerMinute(maxTs: Date | null) {
+    if (!maxTs) return [];
     const data = await this.databaseConnection.query(
-      `SELECT to_char(hour, 'YYYY-MM-DD HH24') AS date,
-        SUM(transactions_count) AS value
-      FROM (
-        SELECT date_trunc('hour', "timestamp") AS hour,
-          transactions_count
-        FROM indexer.blocks
-        WHERE "timestamp" > date_trunc('hour', (
-          SELECT MAX("timestamp") FROM indexer.blocks
-        )) - interval '24 hours'
-      ) t
-      GROUP BY hour
-      ORDER BY hour`,
-      [],
-    );
-    return data.map((row) => ({
-      date: dayjs(row.date).startOf('hour').utcOffset(0, true).toDate(),
-      value: Number(row.value),
-    }));
-  }
-
-  async getMaxTps() {
-    const data = await this.databaseConnection.query(
-      `SELECT to_char(hour, 'YYYY-MM-DD HH24') AS date,
-        MAX(transactions_count) AS value
-      FROM (
-        SELECT date_trunc('hour', "timestamp") AS hour,
-          transactions_count
-        FROM indexer.blocks
-        WHERE "timestamp" > date_trunc('hour', (
-          SELECT MAX("timestamp") FROM indexer.blocks
-        )) - interval '23 hours'
-      ) t
-      GROUP BY hour
-      ORDER BY hour`,
-      [],
-    );
-    return data.map((row) => ({
-      date: dayjs(row.date).startOf('hour').utcOffset(0, true).toDate(),
-      value: Number(row.value),
-    }));
-  }
-
-  async getAverageTpsPerMinute() {
-    const data = await this.databaseConnection.query(
-      `SELECT to_char(minute, 'YYYY-MM-DD HH24:MI') AS date,
+      `SELECT to_char(date_trunc('minute', "timestamp"), 'YYYY-MM-DD HH24:MI') AS date,
         SUM(transactions_count)::float / 60 AS value
-      FROM (
-        SELECT date_trunc('minute', "timestamp") AS minute,
-          transactions_count
-        FROM indexer.blocks
-        WHERE "timestamp" > (
-          SELECT MAX("timestamp") FROM indexer.blocks
-        ) - INTERVAL '24 hours'
-      ) t
-      GROUP BY minute
-      ORDER BY minute ASC`,
-      [],
+      FROM indexer.blocks
+      WHERE "timestamp" > $1::timestamptz - INTERVAL '24 hours'
+      GROUP BY 1
+      ORDER BY 1 ASC`,
+      [maxTs],
     );
     return data.map((row) => ({
       date: dayjs(row.date).startOf('minute').utcOffset(0, true).toDate(),
@@ -291,7 +272,16 @@ export default class BlockDAO {
     }));
   }
 
-  async getRollingStats60s() {
+  async getRollingStats60s(maxTs: Date | null) {
+    if (!maxTs) {
+      return {
+        tps: 0,
+        avgTxPerBlock: 0,
+        avgGasPerBlock: 0,
+        avgBlockSize: 0,
+        peakTps: 0,
+      };
+    }
     const [stats, peak] = await Promise.all([
       this.databaseConnection.query(
         `SELECT
@@ -300,22 +290,18 @@ export default class BlockDAO {
           CASE WHEN COUNT(*) > 0 THEN AVG(gas_used::numeric) ELSE 0 END AS avg_gas_per_block,
           CASE WHEN COUNT(*) > 0 THEN AVG(pg_column_size(data)) ELSE 0 END AS avg_block_size
         FROM indexer.blocks
-        WHERE "timestamp" > (
-          SELECT MAX("timestamp") FROM indexer.blocks
-        ) - INTERVAL '60 seconds'`,
-        [],
+        WHERE "timestamp" > $1::timestamptz - INTERVAL '60 seconds'`,
+        [maxTs],
       ),
       this.databaseConnection.query(
         `SELECT COALESCE(MAX(minute_tps), 0) AS peak_tps
         FROM (
           SELECT SUM(transactions_count)::float / 60 AS minute_tps
           FROM indexer.blocks
-          WHERE "timestamp" > (
-            SELECT MAX("timestamp") FROM indexer.blocks
-          ) - INTERVAL '24 hours'
+          WHERE "timestamp" > $1::timestamptz - INTERVAL '24 hours'
           GROUP BY date_trunc('minute', "timestamp")
         ) t`,
-        [],
+        [maxTs],
       ),
     ]);
     return {
@@ -325,72 +311,6 @@ export default class BlockDAO {
       avgBlockSize: Number(stats[0]?.avg_block_size) || 0,
       peakTps: Number(peak[0]?.peak_tps) || 0,
     };
-  }
-
-  async getAverageGasUsed() {
-    const data = await this.databaseConnection.query(
-      `SELECT to_char(hour, 'YYYY-MM-DD HH24') AS date,
-        AVG(gas_used::numeric) AS value
-      FROM (
-        SELECT date_trunc('hour', "timestamp") AS hour,
-          gas_used
-          FROM indexer.blocks
-          WHERE "timestamp" > date_trunc('hour', (
-            SELECT MAX("timestamp") FROM indexer.blocks
-          )) - interval '24 hours'
-      ) t
-      GROUP BY hour
-      ORDER BY hour`,
-      [],
-    );
-    return data.map((row) => ({
-      date: dayjs(row.date).startOf('hour').utcOffset(0, true).toDate(),
-      value: Number(row.value),
-    }));
-  }
-
-  async getTotalGasUsed() {
-    const data = await this.databaseConnection.query(
-      `SELECT to_char(hour, 'YYYY-MM-DD HH24') AS date,
-        SUM(gas_used::numeric) AS value
-      FROM (
-        SELECT date_trunc('hour', "timestamp") AS hour,
-          gas_used
-          FROM indexer.blocks
-          WHERE "timestamp" > date_trunc('hour', (
-            SELECT MAX("timestamp") FROM indexer.blocks
-          )) - interval '24 hours'
-      ) t
-      GROUP BY hour
-      ORDER BY hour`,
-      [],
-    );
-    return data.map((row) => ({
-      date: dayjs(row.date).startOf('hour').utcOffset(0, true).toDate(),
-      value: Number(row.value),
-    }));
-  }
-
-  async getMaxGasUsed() {
-    const data = await this.databaseConnection.query(
-      `SELECT to_char(hour, 'YYYY-MM-DD HH24') AS date,
-        MAX(gas_used::numeric) AS value
-      FROM (
-        SELECT date_trunc('hour', "timestamp") AS hour,
-          gas_used
-          FROM indexer.blocks
-          WHERE "timestamp" > date_trunc('hour', (
-            SELECT MAX("timestamp") FROM indexer.blocks
-          )) - interval '24 hours'
-      ) t
-      GROUP BY hour
-      ORDER BY hour`,
-      [],
-    );
-    return data.map((row) => ({
-      date: dayjs(row.date).startOf('hour').utcOffset(0, true).toDate(),
-      value: Number(row.value),
-    }));
   }
 
   async getTotalFee() {


### PR DESCRIPTION
## Summary

`BlockResolver._statistics` was firing 9 separate analytics queries against the reader, each one parallel-seq-scanning the 50M+ row `blocks` table. Production EXPLAIN showed 6.14M buffer hits and ~134s execution time per query (with reader CPU pinned), driving ~99% of reader load and ~$22k/mo of the Aurora bill.

This PR fixes the query plan and consolidates without changing the GraphQL response shape, polling cadence, cache TTL, or any external contract.

## Two changes

**1. Pin the analytics window via a single `MAX(timestamp)` lookup, pass as a bound parameter.**

The original queries embedded `(SELECT MAX(timestamp) FROM blocks)` inside the WHERE clause. That made the WHERE filter a runtime `InitPlan` — the planner couldn't see the value, fell back to default selectivity (~33% of the table), estimated ~7.3M rows, and picked a Parallel Seq Scan. With the timestamp passed in as `\$1`, the planner consults the histogram on `timestamp`, accurately estimates ~85K rows, and picks an Index Scan on `blocks_timestamp_idx`.

EXPLAIN cost per query: **6,557,728 → 261,000-269,000** (~25× lower).

Side benefit: all downstream queries now share a single pinned anchor, so the response represents a consistent snapshot.

**2. Consolidate 6 per-hour single-aggregate queries into 1.**

`getTotalTps`, `getAverageTps`, `getMaxTps`, `getTotalGasUsed`, `getAverageGasUsed`, `getMaxGasUsed` all did the same 24h scan and the same `GROUP BY date_trunc('hour', timestamp)`. They are now one `getHourlyStatistics(maxTs)` call returning all six aggregates from a single scan. The resolver projects them out to the existing GraphQL fields.

Combined: ~9 expensive queries per refresh → ~4 (1 hourly + tpsPerMinute + rollingStats60s + totalFee).

## What is **not** changing

- **GraphQL schema:** zero field additions/removals/type changes.
- **Frontend:** zero changes (verified — every consumed field still present with same shape).
- **Polling cadence (`startPoolingAnalytics`):** still 7s. Once we see the new load profile we can decide whether to reduce.
- **`DataCache` TTL:** still 60s.
- **`getTotalFee`:** unchanged (already uses \`hourly_statistics_agg\` from migration 046).
- **`getBlocksDashboard`:** unchanged.
- **`maxTps` array entry count:** preserved via `.slice(-24)` to match the legacy 23h-window behavior even though the consolidated query uses a 24h window for all aggregates.
- **DB schema:** zero changes, no migration.

## Verified

- `tsc --noEmit`: zero new errors in `BlockDAO.ts` / `BlockResolver.ts` (pre-existing errors elsewhere unaffected).
- `pnpm build:lib` (tsup, the production build): succeeds.
- `EXPLAIN` (no ANALYZE) on every rewritten query: all use Index Scan on `blocks_timestamp_idx`, none seq-scan.
- No dynamic dispatch on `blockDAO[...]` anywhere in the repo (grep clean).
- No tests reference any of the changed methods.

## Test plan

- [ ] Local `pnpm dev`: load `/`, hit GraphQL `statistics` and `tps` queries, byte-compare result shape against prod
- [ ] Post-deploy on prod: `pg_stat_statements` should show the 6 deleted query shapes dropping to zero new calls and a single new consolidated query as the top entry, with mean exec time in the hundreds of ms instead of 12s
- [ ] Reader CPU should drop substantially within ~1 minute of deploy

## Rollback

Pure code change, single PR, single commit. Revert the merge.