### PR TITLE
fix(migrations): remove semicolons from inline comments in 049/050

### DIFF
--- a/packages/graphql/database/migrations/049_drop_unused_redundant_indexes.sql
+++ b/packages/graphql/database/migrations/049_drop_unused_redundant_indexes.sql
@@ -21,5 +21,5 @@ DROP INDEX CONCURRENTLY IF EXISTS indexer.inputs__id_idx1;
 DROP INDEX CONCURRENTLY IF EXISTS indexer.balance_tx_hash_idx;
 
 -- Identical column definition to balance_account_asset_id_idx2
--- (account_hash, asset_id, _id DESC); the latter is the one in active use.
+-- on (account_hash, asset_id, _id DESC) — the latter is the one in active use.
 DROP INDEX CONCURRENTLY IF EXISTS indexer.balance_account_hash_asset_id__id_idx;

--- a/packages/graphql/database/migrations/050_tune_autovacuum_large_tables.sql
+++ b/packages/graphql/database/migrations/050_tune_autovacuum_large_tables.sql
@@ -9,22 +9,22 @@
 -- Per-table overrides below scale the trigger thresholds proportionally to
 -- table size so they fire on a more reasonable absolute change.
 
--- 1.92B rows; default analyze trigger ~96M rows of churn.
+-- 1.92B rows, default analyze trigger ~96M rows of churn.
 ALTER TABLE indexer.transactions_accounts
   SET (autovacuum_vacuum_scale_factor = 0.005,
        autovacuum_analyze_scale_factor = 0.001);
 
--- 5.01B rows; default analyze trigger ~250M rows of churn.
+-- 5.01B rows, default analyze trigger ~250M rows of churn.
 ALTER TABLE indexer.inputs
   SET (autovacuum_vacuum_scale_factor = 0.005,
        autovacuum_analyze_scale_factor = 0.001);
 
--- 548M rows; default analyze trigger ~27M rows of churn.
+-- 548M rows, default analyze trigger ~27M rows of churn.
 ALTER TABLE indexer.transactions
   SET (autovacuum_vacuum_scale_factor = 0.005,
        autovacuum_analyze_scale_factor = 0.001);
 
--- 462M rows with steady UPDATE churn (1%+ dead tuples observed); slightly
+-- 462M rows with steady UPDATE churn (1%+ dead tuples observed) — slightly
 -- looser than the insert-mostly tables above.
 ALTER TABLE indexer.balance
   SET (autovacuum_vacuum_scale_factor = 0.01,


### PR DESCRIPTION
## Summary

`scripts/migrate.ts` splits each migration file on `;` before filtering comment-only chunks. A `;` inside a comment line followed by more text on subsequent lines produces a chunk whose first line is non-comment prose — the runner then tries to execute prose as SQL and errors with `syntax error`.

Caught when applying 046–050 to devnet via `pnpm db:migrate`. (Mainnet was unaffected because the prod `CONCURRENTLY` drops were run by hand from `psql` and the `_migrations` row was inserted directly, so the .sql files were never executed end-to-end through the runner.)

This PR replaces the offending semicolons with commas / em dashes:

- `049_drop_unused_redundant_indexes.sql` — 1 comment line
- `050_tune_autovacuum_large_tables.sql` — 4 comment lines

No SQL semantics change — comments only.

## Test plan

- [x] `pnpm db:migrate` against devnet now applies 049 and 050 cleanly
- [ ] Same will apply cleanly to testnet