### PR TITLE
chore: migrate simplystaking URLs to internal sequencer endpoints

### DIFF
--- a/packages/app-commons/src/config.ts
+++ b/packages/app-commons/src/config.ts
@@ -97,10 +97,10 @@ export const COMET_SECURE_API = COMET_SECURE_API_MAP[STAKING_ENV];
 export const STAKING_MAINNET_FALLBACKS: Array<StakingEnvFallback> = [
   {
     COSMOS: {
-      REST: 'https://rest-fuel-seq.simplystaking.xyz',
+      REST: 'https://rest.seq.mainnet.fuel.network',
     },
     COMET: {
-      SECURE: 'https://rpc-fuel-seq.simplystaking.xyz',
+      SECURE: 'https://seq.mainnet.fuel.network',
     },
   },
   {

--- a/packages/app-commons/src/utils/stakingAddresses.ts
+++ b/packages/app-commons/src/utils/stakingAddresses.ts
@@ -106,6 +106,7 @@ export const getCurrentNetworkContracts = (env: string) => {
   return STAKING_CONTRACTS[env.toUpperCase() as StakingEnv];
 };
 
+// TODO: replace with new sequencer block explorer URLs when available
 const SIMPLY_STAKING_EXPLORERS: Record<StakingEnv, string> = {
   MAINNET: 'https://fuel-seq.simplystaking.xyz/fuel-mainnet',
   SANDBOX: 'https://fuel-seq.simplystaking.xyz/fuel-sandbox',

--- a/packages/app-explorer/.env.example
+++ b/packages/app-explorer/.env.example
@@ -41,20 +41,20 @@ VITE_SHOW_CONVERT_BUTTON=true
 VITE_SHOW_CLAIM_BUTTON=true
 
 # Cosmos API Endpoints
-VITE_COSMOS_API_MAINNET=https://rest-fuel-seq.simplystaking.xyz
-VITE_COSMOS_API_SANDBOX=https://sandbox-rest-fuel-seq.simplystaking.xyz
-VITE_COSMOS_API_TESTNET=https://testnet-rest-fuel-seq.simplystaking.xyz
+VITE_COSMOS_API_MAINNET=https://rest.seq.mainnet.fuel.network
+VITE_COSMOS_API_SANDBOX=https://rest.seq.testnet.fuel.network
+VITE_COSMOS_API_TESTNET=https://rest.seq.testnet.fuel.network
 VITE_COSMOS_API_LOCAL=http://localhost:1317
 
-VITE_COSMOS_INDEXER_API_MAINNET=https://indexer-fuel-seq.simplystaking.xyz
-VITE_COSMOS_INDEXER_API_SANDBOX=https://sandbox-indexer-fuel-seq.simplystaking.xyz
-VITE_COSMOS_INDEXER_API_TESTNET=https://testnet-indexer-fuel-seq.simplystaking.xyz
+VITE_COSMOS_INDEXER_API_MAINNET=https://index-api.sequencer.mainnet.fuel.network
+VITE_COSMOS_INDEXER_API_SANDBOX=https://index-api.sequencer.testnet.fuel.network
+VITE_COSMOS_INDEXER_API_TESTNET=https://index-api.sequencer.testnet.fuel.network
 VITE_COSMOS_INDEXER_API_LOCAL=http://localhost:8088
 
 # Comet API Endpoints
-VITE_COMET_SECURE_API_MAINNET=https://rpc-fuel-seq.simplystaking.xyz
-VITE_COMET_SECURE_API_SANDBOX=https://sandbox-rpc-fuel-seq.simplystaking.xyz
-VITE_COMET_SECURE_API_TESTNET=https://testnet-rpc-fuel-seq.simplystaking.xyz
+VITE_COMET_SECURE_API_MAINNET=https://seq.mainnet.fuel.network
+VITE_COMET_SECURE_API_SANDBOX=https://seq.testnet.fuel.network
+VITE_COMET_SECURE_API_TESTNET=https://seq.testnet.fuel.network
 VITE_COMET_SECURE_API_LOCAL=http://localhost:26657
 
 # Extra Mainnet

--- a/packages/graphql/src/application/uc/IndexCosmos.ts
+++ b/packages/graphql/src/application/uc/IndexCosmos.ts
@@ -23,10 +23,9 @@ export default class IndexCosmos {
     while (true) {
       try {
         const network = env.get('FUEL_CHAIN');
-        const baseUrl =
-          network === 'mainnet' ? 'rest-fuel-seq' : 'testnet-rest-fuel-seq';
+        const envPrefix = network === 'mainnet' ? 'mainnet' : 'testnet';
         const response = await fetch(
-          `https://${baseUrl}.simplystaking.xyz/cosmos/tx/v1beta1/txs?query=tx.height=${height}&limit=1000&offset=0`,
+          `https://rest.seq.${envPrefix}.fuel.network/cosmos/tx/v1beta1/txs?query=tx.height=${height}&limit=1000&offset=0`,
         );
         const output = await response.json();
         if (output.total === '0') {

--- a/packages/graphql/src/graphql/resolvers/APYResolver.ts
+++ b/packages/graphql/src/graphql/resolvers/APYResolver.ts
@@ -27,9 +27,8 @@ export class APYResolver {
       };
 
     const network = env.get('FUEL_CHAIN');
-    const prfixUrl =
-      network === 'mainnet' ? 'rest-fuel-seq' : 'testnet-rest-fuel-seq';
-    const baseUrl = `https://${prfixUrl}.simplystaking.xyz`;
+    const envPrefix = network === 'mainnet' ? 'mainnet' : 'testnet';
+    const baseUrl = `https://rest.seq.${envPrefix}.fuel.network`;
     const poolResp = await fetch(
       new URL('/cosmos/staking/v1beta1/pool', baseUrl),
     ).then((resp) => resp.json());

--- a/packages/graphql/src/infra/dao/TEMP_StakingDAO.ts
+++ b/packages/graphql/src/infra/dao/TEMP_StakingDAO.ts
@@ -15,13 +15,10 @@ export const TIME_TO_SEQUENCER_INDEXER_SYNC = 1800;
 
 const network = env.get('FUEL_CHAIN')!;
 const currentNetworkContracts = getCurrentNetworkContracts(network);
-const baseUrlIndexer =
-  network === 'mainnet' ? 'indexer-fuel-seq' : 'testnet-indexer-fuel-seq';
-const baseUrlRPC =
-  network === 'mainnet' ? 'rest-fuel-seq' : 'testnet-rest-fuel-seq';
+const envPrefix = network === 'mainnet' ? 'mainnet' : 'testnet';
 
-const COSMOS_URL_RPC = `https://${baseUrlRPC}.simplystaking.xyz`;
-const COSMOS_URL_INDEXER = `https://${baseUrlIndexer}.simplystaking.xyz`;
+const COSMOS_URL_RPC = `https://rest.seq.${envPrefix}.fuel.network`;
+const COSMOS_URL_INDEXER = `https://index-api.sequencer.${envPrefix}.fuel.network`;
 const base = network === 'mainnet' ? 'mainnet' : 'sepolia';
 const ETH_PROVIDER_URL = `https://eth-${base}.g.alchemy.com/v2/${env.get('ALCHEMY_API_KEY')}`;
 const ETH_PROVIDER = new ethers.JsonRpcProvider(ETH_PROVIDER_URL);


### PR DESCRIPTION
## Summary
- SimplStaking has been decommissioned — their endpoints return 5xx, causing explorer non-responsiveness for users
- Replaces all `*.simplystaking.xyz` URLs in frontend env configs, backend services, and hardcoded fallbacks
- URL mapping derived from actual ingress configs in fuel-deployment-v2

### Changes
- **`.env.example`** — updated all `VITE_COSMOS_API_*`, `VITE_COSMOS_INDEXER_API_*`, `VITE_COMET_SECURE_API_*` URLs
- **`config.ts`** — updated hardcoded mainnet fallback URLs
- **`TEMP_StakingDAO.ts`**, **`APYResolver.ts`**, **`IndexCosmos.ts`** — updated dynamic URL construction in backend
- **`stakingAddresses.ts`** — added TODO for block explorer URLs (no replacement available yet)

### Not changed
- `SIMPLY_STAKING_EXPLORERS` URLs in `stakingAddresses.ts` — block explorer links have no replacement yet (marked with TODO)

### Related
- Companion PR: FuelLabs/fuel-deployment-v2 (infra URL migration)

## Test plan
- [ ] Verify staking page loads and shows APY
- [ ] Verify withdrawal status tracking works
- [ ] Verify Cosmos block indexing continues
- [ ] Test with `VITE_STAKING_ENV=MAINNET` locally