### PR TITLE
chore: remove bridge maintenance banner

### DIFF
--- a/packages/app-portal/src/systems/Bridge/pages/BridgeHome.tsx
+++ b/packages/app-portal/src/systems/Bridge/pages/BridgeHome.tsx
@@ -1,9 +1,5 @@
-import { Alert, Box, Button } from '@fuels/ui';
-import {
-  IconArrowBack,
-  IconHistory,
-  IconInfoCircle,
-} from '@tabler/icons-react';
+import { Box, Button } from '@fuels/ui';
+import { IconArrowBack, IconHistory } from '@tabler/icons-react';
 import { PageTitle } from 'app-commons';
 import { Routes } from 'app-commons';
 
@@ -16,12 +12,6 @@ type BridgeHomeProps = {
   children: ReactNode;
 };
 
-const MAINTENANCE_NOTICE = {
-  message:
-    'The Canonical Bridge is currently undergoing scheduled maintenance. Deposits and withdrawals may be temporarily unavailable. ',
-  boldText: 'Our team is actively working on restoring full functionality.',
-};
-
 export const BridgeHome = ({ children }: BridgeHomeProps) => {
   const classes = styles();
   const location = useLocation();
@@ -31,15 +21,6 @@ export const BridgeHome = ({ children }: BridgeHomeProps) => {
 
   return (
     <Box className={classes.content()}>
-      <Alert color="orange" size="2" variant="surface" className="mb-4">
-        <Alert.Icon>
-          <IconInfoCircle size={20} />
-        </Alert.Icon>
-        <Alert.Text>
-          {MAINTENANCE_NOTICE.message}
-          <b>{MAINTENANCE_NOTICE.boldText}</b>
-        </Alert.Text>
-      </Alert>
       <LayerSwapBanner />
       <PageTitle title="Fuel Bridge">
         {isBridgeHistory ? (


### PR DESCRIPTION
<!--
List the issues this PR closes in a bullet list format, e.g.:
- Closes #X
- Closes FE-Z
-->

# Summary
<!--
Please include a summary of your changes if something is not self-explanatory from the closed issues.
Many times this section is not needed as the closed issues themselves explains the reason of the PR exists. On that case just remove this section it.
-->

Removed the bridge maintenance warning banner from the UI. The bridge is functional. 

# Checklist

- [ ] I've added error handling for all actions/requests, and verified how this error will show on UI. (or there was no error handling)
- [ ] I've reviewed all the copy changed/added in this PR, using AI if needed. (or there was no copy changes)
- [ ] I've included the reference to the issues being closed from Github and/or Linear (or there was no issues)
- [ ] I've changed the Docs to reflect my changes (or it was not needed)
- [ ] I've put docs links where it may be helpful (or it was not needed)
- [ ] I checked the resulting UI both in Light and Dark mode (or no UI changes were made)
- [ ] I **reviewed** the **entire PR** myself (preferably, on GH UI)
