### PR TITLE
chore: serve app.fuel.network routes directly from the explorer

### DIFF
--- a/docker/erc20-deployer/Dockerfile
+++ b/docker/erc20-deployer/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /erc20-deployer/deployer
 # Install Git
 RUN apk update && apk add --no-cache git
 
-RUN npm i -g pnpm
+RUN npm i -g pnpm@9.10.0
 
 # build the ethereum contracts and environment
 RUN pnpm install

--- a/packages/app-explorer/public/blocked-page.html
+++ b/packages/app-explorer/public/blocked-page.html
@@ -87,8 +87,9 @@
         <p>
           Access to our services is restricted in your jurisdiction or if you
           are using a VPN service. Please access the website from an authorized
-          location. Return to the <a class="link-brand" href="http://fuel.network">Fuel homepage</a>.
+          location. Return to the <a class="link-brand" href="https://fuel.network">Fuel homepage</a>.
         </p>
+      </div>
       <div class="footer">
         <a href="https://fuel.network/">
           <svg

--- a/packages/app-explorer/public/blocked-page.html
+++ b/packages/app-explorer/public/blocked-page.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Restricted Location</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+        font-family: "Courier New", Courier, monospace;
+        background: linear-gradient(to bottom, #091b09, #000);
+        color: #ffffff;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+      }
+
+      .container {
+        text-align: center;
+        max-width: 800px;
+        box-sizing: border-box;
+        padding: 20px;
+      }
+
+      .emoji {
+        font-size: 100px;
+      }
+
+      h1 {
+        font-size: 48px;
+        margin: 20px 0;
+      }
+
+      p {
+        font-size: 18px;
+        line-height: 28px;
+        margin: 10px 0;
+      }
+
+      .social-icons {
+        margin: 20px 0;
+      }
+
+      .social-icons a {
+        margin: 0 10px;
+        display: inline-block;
+      }
+
+      .social-icons img {
+        width: 40px;
+        height: 40px;
+      }
+
+      .footer {
+        margin-top: 30px;
+      }
+
+      .footer a {
+        color: #ffffff;
+        text-decoration: none;
+        margin: 0 10px;
+      }
+
+      .footer p {
+        margin-top: 10px;
+        font-size: 14px;
+      }
+
+      .link {
+        text-decoration: none;
+        color: #ffffff;
+      }
+      
+      .link-brand {
+        text-decoration: none;
+        color: #07e982;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="content">
+        <div class="emoji">🤷🏻‍♀️</div>
+        <h1>Oops!</h1>
+        <p>
+          Access to our services is restricted in your jurisdiction or if you
+          are using a VPN service. Please access the website from an authorized
+          location. Return to the <a class="link-brand" href="http://fuel.network">Fuel homepage</a>.
+        </p>
+      <div class="footer">
+        <a href="https://fuel.network/">
+          <svg
+            width="100"
+            height="23"
+            viewBox="0 0 100 23"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M46.3216 21.3132V0H49.2253V20.0429H60.5851L60.521 0.0217283L63.4897 0V21.3132C63.4897 21.5347 63.4468 21.7541 63.3635 21.9588C63.2801 22.1635 63.158 22.3495 63.0039 22.5061C62.85 22.6628 62.6671 22.787 62.466 22.8717C62.2648 22.9565 62.0492 23.0001 61.8314 23H47.9773C47.538 22.9994 47.1169 22.8215 46.8064 22.5052C46.496 22.1889 46.3216 21.7602 46.3216 21.3132Z"
+              fill="white"
+            />
+            <path
+              d="M85.3855 21.3132V0H88.2892V20.0429H100V23H87.0434C86.6036 23 86.1818 22.8223 85.8712 22.506C85.5599 22.1896 85.3855 21.7606 85.3855 21.3132Z"
+              fill="white"
+            />
+            <path
+              d="M28.4195 23H31.3237V13.0114H42.2647V10.0543H31.3211V2.95714H42.084C42.2407 2.95715 42.3942 2.91194 42.5267 2.82677C42.6591 2.7416 42.7652 2.61995 42.8325 2.47594L43.9892 0H30.0747C29.6356 0.000842083 29.2147 0.178918 28.9044 0.495155C28.594 0.811394 28.4197 1.23997 28.4195 1.68685V23Z"
+              fill="white"
+            />
+            <path
+              d="M66.6508 1.68685C66.6508 1.46532 66.6941 1.24598 66.7774 1.04132C66.8607 0.836661 66.9828 0.650702 67.1365 0.494064C67.2908 0.337426 67.4736 0.213175 67.6745 0.128403C67.8753 0.0436314 68.091 0 68.3087 0H82.2211L81.0638 2.47594C80.9966 2.61999 80.8907 2.74167 80.7583 2.82685C80.6259 2.91203 80.4722 2.95721 80.3159 2.95714H69.5545V10.0543H80.4961V13.0114H69.5545V20.0429H82.2211V23H68.3087C67.8695 23 67.4478 22.8223 67.1365 22.506C66.8258 22.1896 66.6508 21.7606 66.6508 21.3132V1.68685Z"
+              fill="white"
+            />
+            <path
+              d="M1.50311 0C1.10455 -2.43452e-08 0.722308 0.161064 0.440435 0.447777C0.158562 0.734489 0.000138101 1.12337 0 1.52892V23H18.7025C19.3354 22.9999 19.9423 22.7441 20.39 22.2888L21.905 20.7472C22.1267 20.5217 22.3025 20.254 22.4224 19.9594C22.5423 19.6648 22.604 19.349 22.604 19.0301V0H1.50311ZM3.66247 2.95714H14.7587L7.40778 10.4369C7.22521 10.6224 6.97773 10.7267 6.71972 10.7268C6.53546 10.7268 6.35494 10.6735 6.19922 10.5732C6.04349 10.473 5.91895 10.3298 5.84006 10.1603L2.99216 4.03348C2.93877 3.91852 2.91482 3.79169 2.92252 3.66479C2.93022 3.53788 2.96933 3.41501 3.03621 3.30762C3.1031 3.20021 3.19559 3.11177 3.30508 3.05049C3.41457 2.98922 3.53751 2.9571 3.66247 2.95714ZM2.90623 20.0429V12.765C2.90636 12.5786 2.97925 12.3998 3.10884 12.2681C3.23844 12.1363 3.41416 12.0623 3.59737 12.0623H10.7494L2.90623 20.0429ZM12.5728 10.2075C12.2457 10.5398 11.8023 10.7266 11.34 10.7268H8.97179L16.0973 3.47703C16.2591 3.31223 16.4513 3.1815 16.6628 3.0923C16.8744 3.0031 17.1011 2.95717 17.3301 2.95714H19.6978L12.5728 10.2075Z"
+              fill="#02F58C"
+            />
+          </svg>
+        </a>
+        <p>© 2024 Fuel Labs. All rights reserved</p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/packages/app-explorer/vercel.json
+++ b/packages/app-explorer/vercel.json
@@ -5,6 +5,26 @@
   "outputDirectory": "dist",
   "rewrites": [
     {
+      "source": "/domains/blocked",
+      "destination": "/blocked-page.html"
+    },
+    {
+      "source": "/earn-points/:path*",
+      "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points/:path*"
+    },
+    {
+      "source": "/earn-points(.*)",
+      "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points$1"
+    },
+    {
+      "source": "/drop/:path*",
+      "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points/drop/:path*"
+    },
+    {
+      "source": "/drop(.*)",
+      "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points/drop$1"
+    },
+    {
       "source": "/(.*)",
       "destination": "/"
     }

--- a/packages/app-explorer/vercel.json
+++ b/packages/app-explorer/vercel.json
@@ -6,7 +6,7 @@
   "rewrites": [
     {
       "source": "/domains/blocked",
-      "destination": "/blocked-page.html"
+      "destination": "/blocked-page"
     },
     {
       "source": "/earn-points/:path*",

--- a/packages/app-explorer/vercel.json
+++ b/packages/app-explorer/vercel.json
@@ -13,16 +13,8 @@
       "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points/:path*"
     },
     {
-      "source": "/earn-points(.*)",
-      "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points$1"
-    },
-    {
       "source": "/drop/:path*",
       "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points/drop/:path*"
-    },
-    {
-      "source": "/drop(.*)",
-      "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points/drop$1"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary

Prepares the explorer to take over app.fuel.network without the fuel-domain proxy in front of it. Today every request is served twice, once by app-domain and once by this project, which doubles the edge request count. After this change the explorer serves the deposits routes and the geo-block page itself, so the domain can be moved to this project with no behaviour change.

## Changes

| Area | Change |
|------|--------|
| Vercel rewrites | Forward /earn-points and /drop to the mainnet deposits app, matching what app-domain does today |
| Blocked page | Serve /domains/blocked from a static page copied from fuel-domain |

## Trade-off

The fuel-domain proxy exists so one hostname can route to several apps and so the backend can be swapped with a one-line commit in a 1-file project. Moving the domain here gives that up:

| Lost | Impact |
|------|--------|
| Fast backend swap | Repointing app.fuel.network becomes a Vercel domain change instead of a commit. Routing edits to /earn-points need a full explorer build. |
| Decoupling | The explorer now hardcodes the deposits app URL. If that app moves, this repo needs a PR. |
| Single routing place | app-devnet.fuel.network and app-mainnet.fuel.network stay on app-domain unless moved too. |

Kept: DNS, Cloudflare, caching, the deposits app, the blocked page. Users see no difference.

Gained: edge requests on this traffic halve, and one hop per request is removed.