### PR TITLE
chore: drop earn-points and drop rewrites, campaigns are closed

### DIFF
--- a/packages/app-explorer/vercel.json
+++ b/packages/app-explorer/vercel.json
@@ -9,14 +9,6 @@
       "destination": "/blocked-page"
     },
     {
-      "source": "/earn-points/:path*",
-      "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points/:path*"
-    },
-    {
-      "source": "/drop/:path*",
-      "destination": "https://app-mainnet-fuel-deposits.vercel.app/earn-points/drop/:path*"
-    },
-    {
       "source": "/(.*)",
       "destination": "/"
     }


### PR DESCRIPTION
## Summary

The Fuel Points Program (`/earn-points`) and the Genesis Drop (`/drop`) campaigns ended a long time ago, but `app.fuel.network` still proxied both paths to the deposits app. Every visit cost one extra edge request, one serverless invocation on the deposits project (uncached, 440 KB for `/earn-points`), plus transfer. These paths now fall through to the explorer like any other unknown route.

This also removes the trailing-slash gap in those rules: `/earn-points/` and every deep link the deposits app redirects to (`/earn-points/foo/`) were not matched by `:path*` and landed on the explorer anyway.

## Changes

| Area | Change |
|------|--------|
| `packages/app-explorer/vercel.json` | Remove the `/earn-points/:path*` and `/drop/:path*` rewrites to `app-mainnet-fuel-deposits.vercel.app`. `/domains/blocked` and the SPA catch-all stay. |

Follow-up outside this repo: remove the matching rules from `fuel-domain` (`app-domain` project), which still serves these paths today.