### PR TITLE
chore: disallow crawlers in robots.txt

### DIFF
--- a/packages/app-explorer/public/robots.txt
+++ b/packages/app-explorer/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Summary

Crawlers spent August 2026 downloading explorer pages and their JS bundles: 24.7M requests and 8.7 TB of Fast Data Transfer on the explorer project, 99% of the team's transfer for the cycle. A firewall rule now denies user agents that identify as bots. This adds the polite signal too, so well-behaved crawlers stop before they hit the firewall. Transaction, block and account pages have no value in a search index.

## Changes

| Area | Change |
|------|--------|
| `packages/app-explorer/public/robots.txt` | New file: `User-agent: *` / `Disallow: /`. |