### PR TITLE
fix(vps): rate limit by the real client IP behind Cloudflare

### DIFF
--- a/.github/workflows/api-lite-uptime.yml
+++ b/.github/workflows/api-lite-uptime.yml
@@ -5,6 +5,9 @@ on:
     - cron: "*/15 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   probe:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -211,6 +211,9 @@ jobs:
     name: E2E Tests api-lite
     runs-on: warp-ubuntu-latest-x64-4x
     timeout-minutes: 14
+    permissions:
+      contents: read
+      packages: read
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/docker/vps/Dockerfile.explorer
+++ b/docker/vps/Dockerfile.explorer
@@ -38,6 +38,12 @@ FROM nginx:1.27-alpine AS runtime
 # variables (api.railway.internal:3000 / the private-network IPv6 resolver) so
 # nginx resolves the api service's address at request time instead of baking
 # it in at build time.
+# Refreshed on every build so the geo block always matches Cloudflare's current published ranges; each fetch must be non-empty or the build fails.
+RUN set -e; \
+    curl -fsS https://www.cloudflare.com/ips-v4 -o /tmp/ips-v4; [ -s /tmp/ips-v4 ]; \
+    curl -fsS https://www.cloudflare.com/ips-v6 -o /tmp/ips-v6; [ -s /tmp/ips-v6 ]; \
+    { sed 's/$/ 1;/' /tmp/ips-v4; sed 's/$/ 1;/' /tmp/ips-v6; } > /etc/nginx/cloudflare-ips.conf; \
+    rm -f /tmp/ips-v4 /tmp/ips-v6
 COPY docker/vps/nginx.conf.template /etc/nginx/templates/default.conf.template
 ENV API_UPSTREAM=api:3000 NGINX_RESOLVER=127.0.0.11 RATE_LIMIT_KEY='$binary_remote_addr' NGINX_ENVSUBST_FILTER='^(API_UPSTREAM|NGINX_RESOLVER|RATE_LIMIT_KEY)$'
 COPY --from=build /app/packages/app-explorer/dist /usr/share/nginx/html

--- a/docker/vps/deploy.md
+++ b/docker/vps/deploy.md
@@ -89,8 +89,12 @@ railway variables --service explorer \
   --set "VITE_FUEL_INDEXER_API=/api" \
   --set "API_UPSTREAM=api.railway.internal:3000" \
   --set "NGINX_RESOLVER=[fd12::10]" \
-  --set 'RATE_LIMIT_KEY=$xff_first'
-# RATE_LIMIT_KEY=$xff_first only because Railway's edge rewrites X-Forwarded-For as "client, edge" (verified 2026-08-29: a client-supplied header is replaced); leave it unset when nginx is itself the public edge.
+  --set 'RATE_LIMIT_KEY=$client_ip'
+# RATE_LIMIT_KEY=$client_ip: $xff_first (first XFF hop) is spoof-resistant only because Railway's edge rewrites
+# X-Forwarded-For as "client, edge" (verified 2026-08-29: a client-supplied header is replaced); once app-testnet.fuel.network
+# is a Cloudflare-proxied CNAME, that first hop is Cloudflare's address for every visitor, so $client_ip instead keys on
+# CF-Connecting-IP whenever $xff_first is a Cloudflare address (nginx.conf.template's geo/map pair), falling back to
+# $xff_first otherwise. Leave RATE_LIMIT_KEY unset (defaults to $binary_remote_addr) when nginx is itself the public edge.
 
 # Deploy both services. `railway up` uploads the working tree directly
 # (no git push, no GitHub connection needed).

--- a/docker/vps/nginx.conf.template
+++ b/docker/vps/nginx.conf.template
@@ -5,6 +5,19 @@ map $http_x_forwarded_for $xff_first {
     "~^([^,\s]+)" $1;
 }
 
+# Marks whether $xff_first is itself a Cloudflare edge address (source var first, geo var second, per nginx geo docs).
+geo $xff_first $via_cloudflare {
+    default 0;
+    include /etc/nginx/cloudflare-ips.conf;
+}
+
+# Behind Cloudflare, key on CF-Connecting-IP instead of the (Cloudflare) first XFF hop; a direct client can't
+# forge this because Railway's edge rewrites XFF, so $xff_first can only be Cloudflare's address when Cloudflare set it.
+map "$via_cloudflare:$http_cf_connecting_ip" $client_ip {
+    default $xff_first;
+    "~^1:(?<ip>.+)$" $ip;
+}
+
 # One zone, keyed by client IP, 10 MB capping each at 20 requests/sec; /api/
 # below allows a 40-request burst before it starts rejecting (nodelay: burst
 # requests are served immediately, not queued/delayed).

--- a/docker/vps/nginx.conf.template
+++ b/docker/vps/nginx.conf.template
@@ -35,6 +35,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # nginx defaults a rate-limited request to 503, which on this box is
+    # indistinguishable from the API being down: the uptime probe hits
+    # /api/health, so a legitimate burst would read as an outage and page
+    # someone. 429 states the actual reason, and clients treat it as "slow
+    # down" rather than "retry the broken server".
+    limit_req_status 429;
+
     gzip on;
     gzip_types text/plain text/css application/json application/javascript image/svg+xml;
     gzip_min_length 1024;


### PR DESCRIPTION
## Summary

When app-testnet.fuel.network moves to Cloudflare in front of Railway, the first X-Forwarded-For hop is a Cloudflare address for every visitor, so the per-IP rate limit would collapse onto a handful of keys. nginx now keys on CF-Connecting-IP whenever the first hop is inside Cloudflare's published ranges, and on the first hop otherwise. This commit was on #699 but landed after the squash merge, so main did not get it. It also adds explicit GITHUB_TOKEN permissions to the two api-lite workflows, which CodeQL flagged on #700.

## Changes

| Area | Change |
|------|--------|
| nginx template | `geo` block over Cloudflare's IP ranges plus a `map` that picks CF-Connecting-IP behind Cloudflare and the first forwarded hop otherwise, exposed as `$client_ip` |
| Explorer image | Fetches Cloudflare's IPv4 and IPv6 ranges at build time into `/etc/nginx/cloudflare-ips.conf`; the build fails on an empty fetch |
| Railway deploy notes | `RATE_LIMIT_KEY=$client_ip` for the explorer service, with the reasoning next to it |
| CI workflows | `permissions: contents: read` on the uptime probe; `contents: read` and `packages: read` on the api-lite e2e job |

🤖 Generated with [Claude Code](https://claude.com/claude-code)