### PR TITLE
fix(graphql): L1 indexer backoff never resolved and froze every contract cursor

### DIFF
--- a/packages/graphql/src/application/uc/IndexL1/IndexL1.test.ts
+++ b/packages/graphql/src/application/uc/IndexL1/IndexL1.test.ts
@@ -127,6 +127,108 @@ describe('IndexL1', () => {
     expect(updateCall?.[1]).toEqual([finalizedNumber + 1, 42]);
   });
 
+  it('retries a failed block timestamp fetch and finishes the cycle', async () => {
+    const log = {
+      blockNumber: 998,
+      transactionHash: '0xtx',
+      topics: [] as string[],
+      data: '0x',
+      index: 0,
+    };
+    let blockAttempts = 0;
+    const getBlock = jest
+      .fn()
+      .mockImplementation(async (tag: string | number) => {
+        if (tag === 'finalized')
+          return { number: 1000, hash: '0xabc', timestamp: 1 };
+        blockAttempts++;
+        if (blockAttempts === 1) throw new Error('rpc hiccup');
+        return { number: tag as number, hash: '0xdef', timestamp: 77 };
+      });
+    const getLogs = jest.fn().mockResolvedValue([log]);
+    const fakeProvider: any = { getBlock, getLogs, getBlockNumber: jest.fn() };
+    queryMock.mockImplementation(async (sql: string) =>
+      sql.startsWith('insert into indexer.contract_l1_logs')
+        ? [{ _id: 7 }]
+        : [],
+    );
+
+    class TestIndexL1 extends IndexL1 {
+      protected createProvider() {
+        return fakeProvider;
+      }
+      protected decodeLog() {
+        return {
+          eventName: 'Transfer',
+          eventSignature: 'Transfer()',
+          args: {},
+        };
+      }
+    }
+
+    await new TestIndexL1().syncContract({
+      _id: 1,
+      block_height: 995,
+      contract_hash: '0x0000000000000000000000000000000000000000',
+      name: 'Token',
+    });
+
+    expect(blockAttempts).toBe(2);
+    const insertCall = queryMock.mock.calls.find((c) =>
+      String(c[0]).startsWith('insert into indexer.contract_l1_logs'),
+    );
+    expect(insertCall?.[1][8]).toEqual(new Date(77 * 1000));
+    const updateCall = queryMock.mock.calls.find((c) =>
+      String(c[0]).includes('update indexer.contract_l1_index'),
+    );
+    expect(updateCall?.[1]).toEqual([1001, 1]);
+  });
+
+  it('keeps syncing other contracts when one contract throws', async () => {
+    queryMock.mockResolvedValue([
+      { _id: 1, block_height: 1, contract_hash: '0x1', name: 'A' },
+      { _id: 2, block_height: 1, contract_hash: '0x2', name: 'B' },
+    ]);
+    const synced: string[] = [];
+
+    class TestIndexL1 extends IndexL1 {
+      async syncContract(contract: { name: string }) {
+        if (contract.name === 'A') throw new Error('boom');
+        synced.push(contract.name);
+      }
+    }
+
+    await expect(new TestIndexL1().tick()).resolves.toBeUndefined();
+    expect(synced).toEqual(['B']);
+  });
+
+  it('calls onStall when a contract sync does not finish within the stall limit', async () => {
+    jest.useFakeTimers();
+    try {
+      queryMock.mockResolvedValue([
+        { _id: 1, block_height: 1, contract_hash: '0x1', name: 'A' },
+      ]);
+      const onStall = jest.fn();
+
+      class TestIndexL1 extends IndexL1 {
+        async syncContract() {
+          await new Promise(() => {});
+        }
+        protected onStall(contract: { name: string }) {
+          onStall(contract.name);
+        }
+      }
+
+      const tick = new TestIndexL1().tick();
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(10 * 60 * 1000);
+      await tick;
+      expect(onStall).toHaveBeenCalledWith('A');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('skips the cycle when the finalized block cannot be fetched', async () => {
     const getBlock = jest.fn().mockRejectedValue(new Error('rpc down'));
     const getLogs = jest.fn();

--- a/packages/graphql/src/application/uc/IndexL1/IndexL1.ts
+++ b/packages/graphql/src/application/uc/IndexL1/IndexL1.ts
@@ -1,4 +1,4 @@
-import { setTimeout } from 'node:timers/promises';
+import { setTimeout as sleep } from 'node:timers/promises';
 import { ethers } from 'ethers';
 import { type Abi, decodeEventLog } from 'viem';
 import { env } from '~/config';
@@ -7,6 +7,8 @@ import { DatabaseConnection } from '~/infra/database/DatabaseConnection';
 import { decodeMessage } from '~/infra/util/util';
 import AbiFactory from './abi/AbiFactory';
 import { createL1Provider } from './createL1Provider';
+
+const SYNC_STALL_MS = 10 * 60 * 1000;
 
 export default class IndexL1 {
   protected createProvider(): ethers.JsonRpcProvider {
@@ -36,13 +38,13 @@ export default class IndexL1 {
         'Timer',
         `Contract: ${contract.name} - Waiting for finalized block`,
       );
-      await setTimeout(10000);
+      await sleep(10000);
       return;
     }
     const lastBlockNumber = finalizedBlock.number;
     if (contract.block_height > lastBlockNumber) {
       logger.debug('Timer', `Contract: ${contract.name} -  Waiting for block`);
-      await setTimeout(10000);
+      await sleep(10000);
       return;
     }
     const abi = AbiFactory.create(network, contract.name);
@@ -73,27 +75,17 @@ export default class IndexL1 {
     );
     const blockIndex: { [blockNumber: number]: number } = {};
     for (const log of logs) {
-      const parsedLog = api.interface.parseLog({
-        topics: log.topics,
-        data: log.data,
-      });
+      const {
+        eventName,
+        eventSignature,
+        args: eventArgs,
+      } = this.decodeLog(api, abi as Abi, log);
       logger.debug(
         'Timer',
-        `Contract: ${contract.name} -  Parsed Log: ${parsedLog}`,
-      );
-      const eventName = parsedLog?.name;
-      const eventSignature = parsedLog?.signature;
-      const data: { eventName: string; args: any } = decodeEventLog({
-        abi: AbiFactory.create(network, contract.name) as Abi,
-        data: log.data as `0x${string}`,
-        topics: log.topics as [],
-      });
-      logger.debug(
-        'Timer',
-        `Contract: ${contract.name} -  Decoded event Log: ${eventName}, ${data.args.data}`,
+        `Contract: ${contract.name} -  Decoded event Log: ${eventName}, ${eventArgs.data}`,
       );
 
-      const decodedArgs = decodeMessage(data.args.data);
+      const decodedArgs = decodeMessage(eventArgs.data);
 
       logger.debug(
         'Timer',
@@ -116,7 +108,7 @@ export default class IndexL1 {
 
             if (attempt < retries) {
               const delay = 2 ** attempt * 1000; // exponential backoff: 2s, 4s, 8s
-              await new Promise((resolve) => setTimeout(resolve as any, delay));
+              await sleep(delay);
             }
           }
         }
@@ -150,7 +142,7 @@ export default class IndexL1 {
           log,
           eventName,
           eventSignature,
-          JSON.stringify(data.args, (_, v) =>
+          JSON.stringify(eventArgs, (_, v) =>
             typeof v === 'bigint' ? v.toString() : v,
           ),
           decodedArgs,
@@ -158,7 +150,7 @@ export default class IndexL1 {
           log.index,
         ],
       );
-      const args = { ...data.args, ...decodedArgs };
+      const args = { ...eventArgs, ...decodedArgs };
       for (const key in args) {
         await connection.query(
           'insert into indexer.contract_l1_args (contract_l1_log_id, key, value) values ($1, $2, $3) on conflict do nothing',
@@ -173,17 +165,77 @@ export default class IndexL1 {
     );
   }
 
-  async execute() {
+  protected decodeLog(
+    api: ethers.Contract,
+    abi: Abi,
+    log: ethers.Log,
+  ): { eventName?: string; eventSignature?: string; args: any } {
+    const parsedLog = api.interface.parseLog({
+      topics: log.topics,
+      data: log.data,
+    });
+    const decoded: { eventName: string; args: any } = decodeEventLog({
+      abi,
+      data: log.data as `0x${string}`,
+      topics: log.topics as [],
+    });
+    return {
+      eventName: parsedLog?.name,
+      eventSignature: parsedLog?.signature,
+      args: decoded.args,
+    };
+  }
+
+  // A hung sync never crashes, so pm2 never restarts it; exit so it does.
+  protected onStall(contract: { name: string }) {
+    logger.error(
+      'Timer',
+      `Contract: ${contract.name} - sync stalled for ${SYNC_STALL_MS}ms, exiting for restart`,
+    );
+    process.exit(1);
+  }
+
+  private async syncContractGuarded(contract: {
+    _id: number;
+    block_height: number;
+    contract_hash: string;
+    name: string;
+  }) {
+    let stallTimer: NodeJS.Timeout | undefined;
+    const stalled = new Promise<void>((resolve) => {
+      stallTimer = globalThis.setTimeout(() => {
+        this.onStall(contract);
+        resolve();
+      }, SYNC_STALL_MS);
+    });
+    try {
+      await Promise.race([this.syncContract(contract), stalled]);
+    } catch (error: any) {
+      logger.error(
+        'Timer',
+        `Contract: ${contract.name} - sync failed, retrying next cycle: ${error.message}`,
+        error,
+      );
+    } finally {
+      clearTimeout(stallTimer);
+    }
+  }
+
+  async tick() {
     const connection = DatabaseConnection.getInstance();
+    const contracts = await connection.query(
+      `select * from indexer.contract_l1_index where status = 'active' and network = $1`,
+      [env.get('FUEL_CHAIN')],
+    );
+    await Promise.all(
+      contracts.map((contract) => this.syncContractGuarded(contract)),
+    );
+  }
+
+  async execute() {
     while (true) {
-      const contracts = await connection.query(
-        `select * from indexer.contract_l1_index where status = 'active' and network = $1`,
-        [env.get('FUEL_CHAIN')],
-      );
-      await Promise.all(
-        contracts.map((contract) => this.syncContract(contract)),
-      );
-      await setTimeout(1000);
+      await this.tick();
+      await sleep(1000);
     }
   }
 }


### PR DESCRIPTION
## Summary

The mainnet L1 indexer stopped on 2026-09-03 and stayed silent for four days. The retry backoff in the block timestamp fetch awaited a promise that can never resolve, so a single transient RPC error froze every contract cursor without crashing the process. Users whose withdrawals were claimed on L1 after that point kept seeing them as ready to process and got a nonce already used revert when they retried. This makes the backoff a real sleep, keeps one failing contract from blocking the others, and exits the process when a sync stalls so pm2 restarts it.

## Changes

| Area | Change |
|------|--------|
| L1 indexer retry backoff | Replace the never-resolving promise with a real sleep between getBlock retries |
| L1 indexer stall watchdog | Exit the process when a contract sync runs longer than 10 minutes so pm2 restarts it with the cursor intact |
| L1 indexer error isolation | Log and retry a contract that throws on the next tick instead of killing the loop for every contract |
| L1 indexer tests | Cover the retry path, per-contract error isolation, and the stall watchdog |