### PR TITLE
fix(app-staking): show finalize errors in the withdraw status dialog

### DIFF
--- a/packages/app-staking/src/systems/Staking/machines/withdrawStatusDialogMachine.ts
+++ b/packages/app-staking/src/systems/Staking/machines/withdrawStatusDialogMachine.ts
@@ -168,6 +168,7 @@ export const withdrawStatusDialogMachine = createMachine(
           FINALIZE: [
             {
               target: 'preparingFinalize',
+              actions: assign({ finalizeError: undefined }),
               cond: (ctx) =>
                 Boolean(
                   ctx.eventData &&
@@ -308,7 +309,6 @@ export const withdrawStatusDialogMachine = createMachine(
       finalized: {
         type: 'final',
       },
-      finalizingError: {},
       closed: {
         type: 'final',
       },
@@ -366,10 +366,11 @@ export type WithdrawStatusDialogMachineState =
 
 export const withdrawStatusDialogMachineSelectors = {
   getError: ({ context }: WithdrawStatusDialogMachineState) =>
-    context.eventError || context.receiptsError,
+    context.eventError || context.receiptsError || context.finalizeError,
   isError: (state: WithdrawStatusDialogMachineState) =>
-    // state.matches('eventError') ||
-    state.matches('finalizingError'),
+    !!state.context.eventError ||
+    !!state.context.receiptsError ||
+    !!state.context.finalizeError,
   isPaused: (state: WithdrawStatusDialogMachineState) => state.context.isPaused,
   isCheckingPaused: (_state: WithdrawStatusDialogMachineState) => false,
   // state.matches('checkingPaused'),


### PR DESCRIPTION
## Summary

When finalizing a staking withdrawal reverted on L1, the dialog showed nothing. The error was stored in the machine but the selectors ignored it and checked a state that no transition ever reached. This surfaced last week when users retried an already claimed withdrawal and got a nonce already used revert with no feedback. The dialog now shows the red error banner for finalize failures, clears it when the user retries, and the dead state is gone.

## Changes

| Area | Change |
|------|--------|
| Withdraw status dialog error banner | Include finalize errors in the error selectors, same as the undelegate machine |
| Withdraw retry | Clear the previous finalize error when the user clicks Finalize again so a successful retry does not stay marked as Error |
| Withdraw machine | Remove the unreachable finalizingError state |