### PR TITLE
chore: build the deploy images in CI and keep the api-lite test run green

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,51 @@
+name: "Build deploy images"
+
+# Railway deploys with `railway up`, which builds docker/vps/Dockerfile.api-lite
+# and docker/vps/Dockerfile.explorer at deploy time. Nothing else builds them:
+# pr-tests.yml only uses Docker to run the local fuel-core test chain, and the
+# image-publishing workflow that was removed built deployment/Dockerfile, a
+# different artifact that no longer exists. Without this job the first time
+# either Dockerfile is built is during a deploy, so a broken build arg, a
+# missing file or a lockfile change surfaces at the worst possible moment.
+# Build both here, publish nothing.
+
+on:
+  pull_request:
+    branches: [main, master, release]
+    types: [opened, synchronize, reopened]
+    paths:
+      # The Dockerfiles themselves.
+      - "docker/vps/**"
+      # Both images COPY the whole repo, so anything under packages/ can change
+      # what they build.
+      - "packages/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+      - ".github/workflows/build-images.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build images
+    runs-on: warp-ubuntu-latest-x64-4x
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build api-lite image
+        run: docker build -f docker/vps/Dockerfile.api-lite -t fuel-explorer-vps/api-lite:ci .
+
+      # Same build args the explorer service is deployed with: the default
+      # NETWORK (mainnet) plus the /api base that nginx proxies. Testnet builds
+      # differ only in which committed env file is copied in, so this one build
+      # covers the Dockerfile itself for both.
+      - name: Build explorer image
+        run: docker build -f docker/vps/Dockerfile.explorer --build-arg VITE_FUEL_INDEXER_API=/api -t fuel-explorer-vps/explorer:ci .

--- a/packages/api-lite/test/parity.test.ts
+++ b/packages/api-lite/test/parity.test.ts
@@ -40,6 +40,16 @@ function flatten(v: unknown, path = '', out = new Map<string, unknown>()) {
 const describeIf = heights.length ? describe : describe.skip;
 
 describeIf('parity with fuel-core', () => {
+  // Jest fails any suite that registers zero tests, and `describe.skip` on its
+  // own does not satisfy that check. The committed block fixtures were removed
+  // to keep them out of the repo (regenerate locally with
+  // `pnpm --filter api-lite fixture <height>`), so on a clean checkout this
+  // file would fail the whole run while all 400+ real tests pass.
+  if (heights.length === 0) {
+    it.skip('no block fixtures present', () => {});
+    return;
+  }
+
   let ctx: { chainId: number; fee: any; baseAssetId: string };
   beforeAll(async () => {
     const p = await new FuelCoreClient(


### PR DESCRIPTION
## Summary

Nothing built the two images Railway deploys. They are built during `railway up`, the e2e workflow only uses Docker for the local fuel-core chain, and the image-publishing workflow that was removed built a different, now-deleted Dockerfile. A broken Dockerfile would therefore first be discovered during a deploy. A new workflow builds both images on pull requests that touch their inputs and publishes nothing.

Separately, removing the committed block fixtures left api-lite's parity suite registering zero tests. Jest fails any suite with no tests, so the package's test command exited non-zero on a clean checkout even though every real test passed.

## Changes

| Area | Change |
|------|--------|
| CI | New `build-images.yml` builds the api-lite and explorer images on PRs touching `docker/vps/**`, `packages/**` or the lockfiles, and on demand |
| api-lite tests | Parity suite registers a skipped placeholder when no block fixtures are present, instead of failing the whole run |