### PR TITLE
fix(api-lite): bound gunzip output for archive and disk-cache reads

### DIFF
--- a/packages/api-lite/src/s3/S3BlockSource.test.ts
+++ b/packages/api-lite/src/s3/S3BlockSource.test.ts
@@ -1,5 +1,10 @@
 import { gzipSync } from 'node:zlib';
-import { BlockNotFound, S3BlockSource, createS3Fetcher } from './S3BlockSource';
+import {
+  BlockNotFound,
+  MAX_BLOCK_BYTES,
+  S3BlockSource,
+  createS3Fetcher,
+} from './S3BlockSource';
 
 describe('S3BlockSource', () => {
   it('gunzips gzip objects', async () => {
@@ -27,6 +32,18 @@ describe('S3BlockSource', () => {
   it('throws BlockNotFound on null', async () => {
     const src = new S3BlockSource(async () => null);
     await expect(src.fetchRaw(7)).rejects.toBeInstanceOf(BlockNotFound);
+  });
+
+  // A crafted gzip object (small on the wire, huge once inflated) must not be
+  // allowed to exhaust the heap. This is an error, not a miss: it must not be
+  // mistaken for BlockNotFound and silently skipped.
+  it('rejects a gzip stream that inflates past the limit, and it is not BlockNotFound', async () => {
+    const huge = Buffer.alloc(MAX_BLOCK_BYTES + 1, 'a');
+    const src = new S3BlockSource(async () => gzipSync(huge));
+    await expect(src.fetchRaw(11)).rejects.toThrow(
+      new RegExp(`11.*${MAX_BLOCK_BYTES}`),
+    );
+    await expect(src.fetchRaw(11)).rejects.not.toBeInstanceOf(BlockNotFound);
   });
 });
 

--- a/packages/api-lite/src/s3/S3BlockSource.ts
+++ b/packages/api-lite/src/s3/S3BlockSource.ts
@@ -8,6 +8,11 @@ export type ObjectFetcher = (key: string) => Promise<Uint8Array | null>;
 // unreachable server on the same schedule.
 const S3_FETCH_TIMEOUT_MS = 15_000;
 
+// Caps gunzipSync's output so a crafted (or corrupt) gzip object -- small on
+// the wire, huge once inflated -- cannot exhaust the 768 MB heap. BlockStore
+// applies the same limit to its disk cache reads.
+export const MAX_BLOCK_BYTES = 64 * 1024 * 1024;
+
 export class BlockNotFound extends Error {
   constructor(public readonly height: number) {
     super(`block ${height} not in S3`);
@@ -87,7 +92,19 @@ export class S3BlockSource {
     const bytes = await this.fetcher(key);
     if (bytes === null) throw new BlockNotFound(height);
     if (bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b) {
-      return gunzipSync(bytes);
+      try {
+        return gunzipSync(bytes, { maxOutputLength: MAX_BLOCK_BYTES });
+      } catch (error) {
+        // A too-large block is a real error, not a miss -- it must not be
+        // (and must not be mistaken for) BlockNotFound, which would make the
+        // indexer silently skip the height.
+        if ((error as { code?: string })?.code === 'ERR_BUFFER_TOO_LARGE') {
+          throw new Error(
+            `block ${height} inflates past the ${MAX_BLOCK_BYTES} byte limit`,
+          );
+        }
+        throw error;
+      }
     }
     return bytes;
   }

--- a/packages/api-lite/src/store/BlockStore.test.ts
+++ b/packages/api-lite/src/store/BlockStore.test.ts
@@ -10,7 +10,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { gunzipSync, gzipSync } from 'node:zlib';
-import { BlockNotFound } from '../s3/S3BlockSource';
+import { BlockNotFound, MAX_BLOCK_BYTES } from '../s3/S3BlockSource';
 import { BlockStore } from './BlockStore';
 
 function fakeBlock(height: number, pad = 0) {
@@ -169,6 +169,24 @@ describe('BlockStore', () => {
     expect(() => JSON.parse(raw.toString('utf8'))).toThrow();
     const gunzipped = JSON.parse(gunzipSync(raw).toString('utf8'));
     expect(gunzipped.height).toBe('42');
+  });
+
+  // A disk cache file that inflates past the limit is handled the same as a
+  // corrupt one: readDisk's catch already falls through to the legacy path
+  // and then to a miss, so this must not throw or wedge the cache.
+  it('treats a disk cache file that inflates past the limit like a corrupt file', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'bs-toolarge-'));
+    mkdirSync(join(dataDir, 'blocks'), { recursive: true });
+    // Valid JSON once inflated, so size is the only thing that can fail --
+    // an invalid payload would hit the same catch via JSON.parse and pass
+    // whether or not the output bound is applied.
+    const big = JSON.stringify(fakeBlock(77, MAX_BLOCK_BYTES));
+    writeFileSync(join(dataDir, 'blocks', '77.json.gz'), gzipSync(big));
+    const { store, calls } = makeStore({ dataDir });
+
+    const block = await store.get(77);
+    expect(block?.height).toBe('77');
+    expect(calls).toEqual([77]); // fell through to the source, same as a corrupt file
   });
 
   it('reads a legacy plain .json file from disk without refetching', async () => {

--- a/packages/api-lite/src/store/BlockStore.ts
+++ b/packages/api-lite/src/store/BlockStore.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { gunzipSync, gzipSync } from 'node:zlib';
 import { LRUCache } from 'lru-cache';
 import type { GQLBlock } from '~/graphql/generated/sdk-provider';
-import { BlockNotFound } from '../s3/S3BlockSource';
+import { BlockNotFound, MAX_BLOCK_BYTES } from '../s3/S3BlockSource';
 
 type Opts = {
   source?: { fetchRaw(height: number): Promise<Uint8Array> };
@@ -400,7 +400,11 @@ export class BlockStore {
   private async readDisk(height: number): Promise<GQLBlock | null> {
     try {
       const gz = await fs.readFile(this.gzPath(height));
-      return JSON.parse(gunzipSync(gz).toString('utf8')) as GQLBlock;
+      // A too-large cache file is handled the same as a corrupt one: this
+      // catch already falls through to the legacy path and then to a miss.
+      return JSON.parse(
+        gunzipSync(gz, { maxOutputLength: MAX_BLOCK_BYTES }).toString('utf8'),
+      ) as GQLBlock;
     } catch {
       /* fall through to the legacy uncompressed path */
     }


### PR DESCRIPTION
## Summary

A crafted or corrupt gzip object — small on the wire, huge once decompressed — could exhaust the service's 768 MB heap, because neither the S3/R2 archive read path nor the on-disk block cache read path capped how much decompressed data `gunzipSync` was allowed to produce. Both paths now pass a 64 MiB output limit to `gunzipSync`. A too-large archive object is now a named error (not mistaken for a missing block, which would otherwise get silently skipped), and a too-large disk cache file is treated the same way the code already treats a corrupt one — it falls through to the legacy path and then to a cache miss.

## Changes

| Area | Change |
|---|---|
| `packages/api-lite/src/s3/S3BlockSource.ts` | Added `MAX_BLOCK_BYTES` (64 MiB) constant; `fetchRaw` passes it as `maxOutputLength` to `gunzipSync` and rethrows Node's `ERR_BUFFER_TOO_LARGE` as a descriptive `Error` naming the height and limit, distinct from `BlockNotFound` |
| `packages/api-lite/src/store/BlockStore.ts` | `readDisk` passes `MAX_BLOCK_BYTES` as `maxOutputLength` to `gunzipSync`; the existing catch-and-fall-through already treats the resulting error like any other corrupt cache file |
| `packages/api-lite/src/s3/S3BlockSource.test.ts` | New test asserting an over-limit gzip object rejects with an error naming the height and limit, and is not `BlockNotFound` |
| `packages/api-lite/src/store/BlockStore.test.ts` | New test asserting an over-limit disk cache file is handled like a corrupt file (falls through to the source, no throw) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
