### PR TITLE
fix(api-lite): validate staking page size and cursor params

### DIFF
--- a/packages/api-lite/src/staking/PaginatedParams.test.ts
+++ b/packages/api-lite/src/staking/PaginatedParams.test.ts
@@ -38,4 +38,46 @@ describe('PaginatedParams', () => {
       'Maximum page size allowed is 4',
     );
   });
+
+  // SQLite treats a negative LIMIT as unlimited, so last=-1 must not reach
+  // L1Index's `LIMIT @limit`.
+  it('throws on a negative last', () => {
+    expect(() => new PaginatedParams({ last: '-1' })).toThrow(
+      'Page size must be an integer between 1 and 50',
+    );
+  });
+
+  it('throws on a zero last', () => {
+    expect(() => new PaginatedParams({ last: '0' })).toThrow(
+      'Page size must be an integer between 1 and 50',
+    );
+  });
+
+  it('throws on a non-integer last', () => {
+    expect(() => new PaginatedParams({ last: '1.5' })).toThrow(
+      'Page size must be an integer between 1 and 50',
+    );
+  });
+
+  it('throws on a non-numeric last', () => {
+    expect(() => new PaginatedParams({ last: 'abc' })).toThrow(
+      'Page size must be an integer between 1 and 50',
+    );
+  });
+
+  it('throws a ValidationError for an invalid last, not a plain Error', () => {
+    expect(() => new PaginatedParams({ last: '-1' })).toThrow(ValidationError);
+  });
+
+  it('throws on a non-numeric after cursor instead of silently becoming NaN', () => {
+    expect(() => new PaginatedParams({ after: 'abc' })).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('throws on a non-numeric before cursor instead of silently becoming NaN', () => {
+    expect(() => new PaginatedParams({ before: 'abc' })).toThrow(
+      ValidationError,
+    );
+  });
 });

--- a/packages/api-lite/src/staking/PaginatedParams.ts
+++ b/packages/api-lite/src/staking/PaginatedParams.ts
@@ -1,6 +1,19 @@
 import { ValidationError } from '../errors';
 import type { PaginationDirection } from './types';
 
+// Cursors are row ids (see L1Index.queryStakingEvents's `_id = @cursor`
+// lookup and StakingStore.getEvents's startCursor/endCursor, both bare
+// integers) -- Number() on a non-numeric value would silently become NaN
+// and bind into the SQL lookup as such, so reject anything that isn't an
+// integer up front.
+function parseCursor(value: string): number {
+  const cursor = Number(value);
+  if (!Number.isInteger(cursor)) {
+    throw new ValidationError('Cursor must be an integer');
+  }
+  return cursor;
+}
+
 export class PaginatedParams {
   cursor: number | null;
   direction: PaginationDirection;
@@ -13,17 +26,32 @@ export class PaginatedParams {
     this.cursor = null;
     this.direction = 'before';
     if (params.after) {
-      this.cursor = Number(params.after);
+      this.cursor = parseCursor(params.after);
       this.direction = 'after';
     }
     if (params.before) {
-      this.cursor = Number(params.before);
+      this.cursor = parseCursor(params.before);
       this.direction = 'before';
     }
 
     const last = params.last ? Number(params.last) : undefined;
-    if (last !== undefined && last > maxPageSize) {
-      throw new ValidationError(`Maximum page size allowed is ${maxPageSize}`);
+    if (last !== undefined) {
+      // Checked separately from the maxPageSize cap below so callers keep
+      // seeing the existing "Maximum page size allowed" message for an
+      // over-cap value (rest/router.test.ts asserts on it) while 0,
+      // negatives and non-integers -- which used to slip through as -1 did,
+      // reaching SQLite's `LIMIT @limit` as an unlimited scan -- get the new
+      // message.
+      if (!Number.isInteger(last) || last < 1) {
+        throw new ValidationError(
+          `Page size must be an integer between 1 and ${maxPageSize}`,
+        );
+      }
+      if (last > maxPageSize) {
+        throw new ValidationError(
+          `Maximum page size allowed is ${maxPageSize}`,
+        );
+      }
     }
 
     this.last = last || 10;


### PR DESCRIPTION

## Summary

The staking REST pagination parameters accepted invalid values that could
degrade or crash a request. A negative `last` (page size) was not rejected
and reached SQLite as an unlimited `LIMIT`, causing a single request to
process every matching row. A non-numeric `after`/`before` cursor silently
became `NaN` instead of being rejected. Both now throw a clear validation
error instead of reaching the database.

## Changes

| Area | Change |
| --- | --- |
| `packages/api-lite/src/staking/PaginatedParams.ts` | Reject `last` values that are 0, negative, non-integer or NaN with a new `ValidationError` message; keep the existing over-cap message and the default of 10 when absent. Reject non-integer `after`/`before` cursors with a `ValidationError` instead of letting them become `NaN`. |
| `packages/api-lite/src/staking/PaginatedParams.test.ts` | Add coverage for `last` of -1, 0, 1.5 and "abc", and for non-numeric `after`/`before` cursors. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
